### PR TITLE
[Actions] Use the new way to add GNU Make to the PATH variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       run: brew install ldid fakeroot make
     
     - name: Add GNU make to PATH
-      run: echo "::add-path::$(brew --prefix make)/libexec/gnubin"
+      run: echo "$(brew --prefix make)/libexec/gnubin" >> $GITHUB_PATH
 
     - name: Install Theos
       uses: actions/checkout@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       run: brew install ldid fakeroot make dpkg
     
     - name: Add GNU make to PATH
-      run: echo "::add-path::$(brew --prefix make)/libexec/gnubin"
+      run: echo "$(brew --prefix make)/libexec/gnubin" >> $GITHUB_PATH
 
     - name: Install Theos
       uses: actions/checkout@master


### PR DESCRIPTION
See this GitHub blog post for more information: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
