### PR TITLE
[App] Update entitlements to fix crashes on iOS 14

### DIFF
--- a/Zebra/Zebra.entitlements
+++ b/Zebra/Zebra.entitlements
@@ -40,5 +40,11 @@
 		<array>
 			<string>com.apple.mobilesafari</string>
 		</array>
+		<key>com.apple.security.iokit-user-client-class</key>
+		<array>
+			<string>AGXDeviceUserClient</string>
+			<string>IOHDIXControllerUserClient</string>
+			<string>IOSurfaceRootUserClient</string>
+		</array>
 	</dict>
 </plist>


### PR DESCRIPTION
This fixes an issue with Zebra crashing when used on iOS 14 with the 'Bold Text' option enabled.