### PR TITLE
Payment API Reimplementation

### DIFF
--- a/Zebra/Downloads/ZBDownloadManager.m
+++ b/Zebra/Downloads/ZBDownloadManager.m
@@ -232,52 +232,52 @@
 }
 
 - (void)authorizeDownloadForPackage:(ZBPackage *)package completion:(void (^)(NSURL *downloadURL, NSError *error))completion {
-//    ZBSource *source = [package source];
-//    UICKeyChainStore *keychain = [UICKeyChainStore keyChainStoreWithService:[ZBAppDelegate bundleID] accessGroup:nil];
-//    
-//    NSDictionary *question = @{
-//                    @"token": [keychain stringForKey:[source repositoryURI]] ?: @"none",
-//                    @"udid": [ZBDevice UDID],
-//                    @"device": [ZBDevice deviceModelID],
-//                    @"version": package.version,
-//                    @"repo": [source repositoryURI]
-//    };
-//    NSData *requestData = [NSJSONSerialization dataWithJSONObject:question options:(NSJSONWritingOptions)0 error:nil];
-//    
-//    NSURL *requestURL = [[source paymentVendorURL] URLByAppendingPathComponent:[NSString stringWithFormat:@"package/%@/authorize_download", [package identifier]]];
-//    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:requestURL];
-//    [request setHTTPMethod:@"POST"];
-//    [request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
-//    [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
-//    [request setValue:[NSString stringWithFormat:@"Zebra/%@ (%@; iOS/%@)", PACKAGE_VERSION, [ZBDevice deviceType], [[UIDevice currentDevice] systemVersion]] forHTTPHeaderField:@"User-Agent"];
-//    [request setValue:[NSString stringWithFormat:@"%lu", (unsigned long)[requestData length]] forHTTPHeaderField:@"Content-Length"];
-//    [request setHTTPBody:requestData];
-//    
-//    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
-//    NSURLSessionDataTask *task = [session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-//        if (data && !error) {
-//            NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:nil];
-//            if ([json valueForKey:@"url"]) {
-//                NSURL *downloadURL = [NSURL URLWithString:json[@"url"]];
-//                if (downloadURL && [[downloadURL scheme] isEqualToString:@"https"]) {
-//                    completion(downloadURL, NULL);
-//                }
-//                else {
-//                    NSError *badURL = [NSError errorWithDomain:NSURLErrorDomain code:808 userInfo:@{NSLocalizedDescriptionKey: @"Couldn't parse download URL for paid package"}];
-//                    completion(NULL, badURL);
-//                }
-//            }
-//            else {
-//                NSError *badURL = [NSError errorWithDomain:NSURLErrorDomain code:808 userInfo:@{NSLocalizedDescriptionKey: @"Did not receive download URL for paid package"}];
-//                completion(NULL, badURL);
-//            }
-//        }
-//        else if (error) {
-//            completion(NULL, error);
-//        }
-//    }];
-//    
-//    [task resume];
+    ZBSource *source = [package source];
+    UICKeyChainStore *keychain = [UICKeyChainStore keyChainStoreWithService:[ZBAppDelegate bundleID] accessGroup:nil];
+    
+    NSDictionary *question = @{
+                    @"token": [keychain stringForKey:[source repositoryURI]] ?: @"none",
+                    @"udid": [ZBDevice UDID],
+                    @"device": [ZBDevice deviceModelID],
+                    @"version": package.version,
+                    @"repo": [source repositoryURI]
+    };
+    NSData *requestData = [NSJSONSerialization dataWithJSONObject:question options:(NSJSONWritingOptions)0 error:nil];
+    
+    NSURL *requestURL = [source.paymentEndpointURL URLByAppendingPathComponent:[NSString stringWithFormat:@"package/%@/authorize_download", [package identifier]]];
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:requestURL];
+    [request setHTTPMethod:@"POST"];
+    [request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+    [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+    [request setValue:[NSString stringWithFormat:@"Zebra/%@ (%@; iOS/%@)", PACKAGE_VERSION, [ZBDevice deviceType], [[UIDevice currentDevice] systemVersion]] forHTTPHeaderField:@"User-Agent"];
+    [request setValue:[NSString stringWithFormat:@"%lu", (unsigned long)[requestData length]] forHTTPHeaderField:@"Content-Length"];
+    [request setHTTPBody:requestData];
+    
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
+    NSURLSessionDataTask *task = [session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        if (data && !error) {
+            NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:nil];
+            if ([json valueForKey:@"url"]) {
+                NSURL *downloadURL = [NSURL URLWithString:json[@"url"]];
+                if (downloadURL && [[downloadURL scheme] isEqualToString:@"https"]) {
+                    completion(downloadURL, NULL);
+                }
+                else {
+                    NSError *badURL = [NSError errorWithDomain:NSURLErrorDomain code:808 userInfo:@{NSLocalizedDescriptionKey: @"Couldn't parse download URL for paid package"}];
+                    completion(NULL, badURL);
+                }
+            }
+            else {
+                NSError *badURL = [NSError errorWithDomain:NSURLErrorDomain code:808 userInfo:@{NSLocalizedDescriptionKey: @"Did not receive download URL for paid package"}];
+                completion(NULL, badURL);
+            }
+        }
+        else if (error) {
+            completion(NULL, error);
+        }
+    }];
+    
+    [task resume];
 }
 
 #pragma mark - Handling Downloaded Files

--- a/Zebra/Downloads/ZBDownloadManager.m
+++ b/Zebra/Downloads/ZBDownloadManager.m
@@ -86,6 +86,11 @@
                 
             [self downloadPackagesFileWithExtension:@"bz2" fromSource:source];
                 
+            if ([source.mainDirectoryURL.scheme isEqual:@"https"]) {
+                [self checkForPaymentEndpointFromSource:source];
+                [self checkForFeaturedPackagesFromSource:source];
+            }
+            
             [downloadDelegate startedDownloadingSource:source];
         } else { // This is the local source
             NSError *fileError = nil;
@@ -118,6 +123,39 @@
     source.packagesTaskIdentifier = packagesTask.taskIdentifier;
     [sourceTasksMap setObject:source forKey:@(packagesTask.taskIdentifier)];
     [packagesTask resume];
+}
+
+- (void)checkForPaymentEndpointFromSource:(ZBBaseSource *)source {
+    NSURL *paymentEndpointURL = [source.mainDirectoryURL URLByAppendingPathComponent:@"payment_endpoint"];
+    NSURLSessionDataTask *endpointTask = [[NSURLSession sharedSession] dataTaskWithURL:paymentEndpointURL completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        source.releaseTasksCompleted++;
+        
+        if (data && !error && ((NSHTTPURLResponse *)response).statusCode == 200) {
+            NSString *vendorURL = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+            source.paymentEndpointURL = [NSURL URLWithString:vendorURL];
+        }
+        [self task:NULL completedDownloadedForFile:@"payment_endpoint" fromSource:source withError:NULL];
+    }];
+    
+    [endpointTask resume];
+}
+
+- (void)checkForFeaturedPackagesFromSource:(ZBBaseSource *)source {
+    NSURL *paymentEndpointURL = [source.mainDirectoryURL URLByAppendingPathComponent:@"payment_endpoint"];
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:paymentEndpointURL];
+    request.HTTPMethod = @"HEAD";
+    
+    NSURLSessionDataTask *endpointTask = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        source.releaseTasksCompleted++;
+        if (((NSHTTPURLResponse *)response).statusCode == 200 && !error) {
+            source.supportsFeaturedPackages = YES;
+        } else {
+            source.supportsFeaturedPackages = NO;
+        }
+        [self task:NULL completedDownloadedForFile:@"sileo-featured.json" fromSource:source withError:NULL];
+    }];
+    
+    [endpointTask resume];
 }
 
 #pragma mark - Downloading Packages
@@ -250,15 +288,13 @@
             
             [self cancelTasksForSource:source]; // Cancel the other task for this source.
             [downloadDelegate finishedDownloadingSource:source withError:@[error]];
-        }
-        else if (task.taskIdentifier == source.releaseTaskIdentifier) { //This is a Release file that failed. We don't really care that much about the Release file (since we can function without one) but we should at least *warn* the user so that they might bug the source maintainer :)
+        } else if (task.taskIdentifier == source.releaseTaskIdentifier) { //This is a Release file that failed. We don't really care that much about the Release file (since we can function without one) but we should at least *warn* the user so that they might bug the source maintainer :)
             NSString *description = [NSString stringWithFormat:NSLocalizedString(@"Could not download Release file from %@. Reason: %@", @""), source.repositoryURI, error.localizedDescription];
             
-            source.releaseTaskCompleted = YES;
+            source.releaseTasksCompleted++;
             source.releaseFilePath = nil;
             [self postStatusUpdate:description atLevel:ZBLogLevelWarning];
-        }
-        else if (task.taskIdentifier == source.packagesTaskIdentifier) { //This is a packages file that failed, we should be able to try again with a Packages.gz or a Packages file
+        } else if (task.taskIdentifier == source.packagesTaskIdentifier) { //This is a packages file that failed, we should be able to try again with a Packages.gz or a Packages file
             NSURL *url = [[task originalRequest] URL];
             if (![url pathExtension]) { //No path extension, Packages file download failed :(
                 NSString *filename = [[task response] suggestedFilename];
@@ -276,14 +312,12 @@
                 [self cancelTasksForSource:source];
                 
                 [downloadDelegate finishedDownloadingSource:source withError:@[error]];
-            }
-            else { //Tries to download another filetype
+            } else { //Tries to download another filetype
                 NSArray *options = @[@"bz2", @"gz", @"xz", @"lzma", @""];
                 NSUInteger nextIndex = [options indexOfObject:[url pathExtension]] + 1;
                 if (nextIndex < options.count) {
                     [self downloadPackagesFileWithExtension:[options objectAtIndex:nextIndex] fromSource:source];
-                }
-                else { //Should never happen but lets catch the error just in case
+                } else { //Should never happen but lets catch the error just in case
                     NSString *description = [NSString stringWithFormat:NSLocalizedString(@"Could not download Packages file from %@. Reason: %@", @""), source.repositoryURI, error.localizedDescription];
                     
                     source.packagesTaskCompleted = YES;
@@ -295,13 +329,12 @@
                     [downloadDelegate finishedDownloadingSource:source withError:@[error]];
                 }
             }
-        }
-        else { //Since we cannot determine which task this is, we need to cancel the entire source download :( (luckily this should never happen)
+        } else  { //Since we cannot determine which task this is, we need to cancel the entire source download :( (luckily this should never happen)
             NSString *description = [NSString stringWithFormat:NSLocalizedString(@"Could not download one or more files from %@. Reason: %@", @""), source.repositoryURI, error.localizedDescription];
             
             source.packagesTaskCompleted = YES;
             source.packagesFilePath = nil;
-            source.releaseTaskCompleted = YES;
+            source.releaseTasksCompleted = 3;
             source.releaseFilePath = nil;
             
             [self postStatusUpdate:description atLevel:ZBLogLevelError];
@@ -309,18 +342,16 @@
             
             [downloadDelegate finishedDownloadingSource:source withError:@[error]];
         }
-    }
-    else {
+    } else {
         if (task.taskIdentifier == source.packagesTaskIdentifier) {
             source.packagesTaskCompleted = YES;
             source.packagesFilePath = path;
-        }
-        else if (task.taskIdentifier == source.releaseTaskIdentifier) {
-            source.releaseTaskCompleted = YES;
+        } else if (task.taskIdentifier == source.releaseTaskIdentifier) {
+            source.releaseTasksCompleted++;
             source.releaseFilePath = path;
         }
         
-        if (source.releaseTaskCompleted && source.packagesTaskCompleted) {
+        if (source.releaseTasksCompleted == 3 && source.packagesTaskCompleted) {
             [downloadDelegate finishedDownloadingSource:source withError:NULL];
         }
     }
@@ -328,8 +359,7 @@
     //Remove task identifiers
     if (task.taskIdentifier == source.packagesTaskIdentifier) {
         source.packagesTaskIdentifier = -1;
-    }
-    else if (task.taskIdentifier == source.releaseTaskIdentifier) {
+    } else if (task.taskIdentifier == source.releaseTaskIdentifier) {
         source.releaseTaskIdentifier = -1;
     }
     

--- a/Zebra/Downloads/ZBDownloadManager.m
+++ b/Zebra/Downloads/ZBDownloadManager.m
@@ -89,6 +89,8 @@
             if ([source.mainDirectoryURL.scheme isEqual:@"https"]) {
                 [self checkForPaymentEndpointFromSource:source];
                 [self checkForFeaturedPackagesFromSource:source];
+            } else {
+                source.releaseTasksCompleted += 2;
             }
             
             [downloadDelegate startedDownloadingSource:source];

--- a/Zebra/Managers/ZBDatabaseManager.m
+++ b/Zebra/Managers/ZBDatabaseManager.m
@@ -332,9 +332,11 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
                                           "distribution TEXT, "
                                           "label TEXT, "
                                           "origin TEXT, "
+                                          "paymentEndpoint TEXT, "
                                           "remote BOOLEAN, "
                                           "sourceDescription TEXT, "
                                           "suite TEXT, "
+                                          "supportsFeaturedPackages INTEGER, "
                                           "url TEXT, "
                                           "uuid TEXT, "
                                           "version TEXT, "
@@ -407,7 +409,7 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
         case ZBDatabaseStatementTypeSourceWithUUID:
             return @"SELECT * FROM " SOURCES_TABLE_NAME " WHERE uuid = ?;";
         case ZBDatabaseStatementTypeInsertSource:
-            return @"INSERT INTO " SOURCES_TABLE_NAME "(architectures, archiveType, codename, components, distribution, label, origin, remote, sourceDescription, suite, url, uuid, version) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);";
+            return @"INSERT INTO " SOURCES_TABLE_NAME "(architectures, archiveType, codename, components, distribution, label, origin, paymentEndpoint, remote, sourceDescription, suite, supportsFeaturedPackages, url, uuid, version) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);";
         case ZBDatabaseStatementTypeSectionReadout:
             return @"SELECT section, COUNT(DISTINCT identifier) from " PACKAGES_TABLE_NAME " WHERE source = ? GROUP BY section ORDER BY section";
         case ZBDatabaseStatementTypePackagesInSourceCount:
@@ -1363,9 +1365,11 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
         sqlite3_bind_text(statement, ZBSourceColumnDistribution + 1, source[ZBSourceColumnDistribution], -1, SQLITE_TRANSIENT);
         sqlite3_bind_text(statement, ZBSourceColumnLabel + 1, source[ZBSourceColumnLabel], -1, SQLITE_TRANSIENT);
         sqlite3_bind_text(statement, ZBSourceColumnOrigin + 1, source[ZBSourceColumnOrigin], -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(statement, ZBSourceColumnPaymentEndpoint + 1, source[ZBSourceColumnPaymentEndpoint], -1, SQLITE_TRANSIENT);
         sqlite3_bind_int(statement, ZBSourceColumnRemote + 1, *(int *)source[ZBSourceColumnRemote]);
         sqlite3_bind_text(statement, ZBSourceColumnDescription + 1, source[ZBSourceColumnDescription], -1, SQLITE_TRANSIENT);
         sqlite3_bind_text(statement, ZBSourceColumnSuite + 1, source[ZBSourceColumnSuite], -1, SQLITE_TRANSIENT);
+        sqlite3_bind_int(statement, ZBSourceColumnSupportsFeaturedPackages + 1, *(int *)source[ZBSourceColumnSupportsFeaturedPackages]);
         sqlite3_bind_text(statement, ZBSourceColumnURL + 1, source[ZBSourceColumnURL], -1, SQLITE_TRANSIENT);
         sqlite3_bind_text(statement, ZBSourceColumnUUID + 1, source[ZBSourceColumnUUID], -1, SQLITE_TRANSIENT);
         sqlite3_bind_text(statement, ZBSourceColumnVersion + 1, source[ZBSourceColumnVersion], -1, SQLITE_TRANSIENT);

--- a/Zebra/Managers/ZBSourceManager.m
+++ b/Zebra/Managers/ZBSourceManager.m
@@ -476,8 +476,12 @@
         strcpy(source[ZBSourceColumnURL], baseSource.repositoryURI.UTF8String);
         strcpy(source[ZBSourceColumnUUID], baseSource.uuid.UTF8String);
         
-        NSString *paymentEndpointString = baseSource.paymentEndpointURL.absoluteString;
-        if (paymentEndpointString) strcpy(source[ZBSourceColumnPaymentEndpoint], paymentEndpointString.UTF8String);
+        if ([baseSource.paymentEndpointURL.scheme isEqual:@"https"]) {
+            NSString *paymentEndpointString = baseSource.paymentEndpointURL.absoluteString;
+            if (paymentEndpointString) strcpy(source[ZBSourceColumnPaymentEndpoint], paymentEndpointString.UTF8String);
+        } else {
+            strcpy(source[ZBSourceColumnPaymentEndpoint], "\0");
+        }
         
         int supportsFeatured = baseSource.supportsFeaturedPackages;
         memcpy(source[ZBSourceColumnSupportsFeaturedPackages], &supportsFeatured, 1);

--- a/Zebra/Managers/ZBSourceManager.m
+++ b/Zebra/Managers/ZBSourceManager.m
@@ -476,6 +476,12 @@
         strcpy(source[ZBSourceColumnURL], baseSource.repositoryURI.UTF8String);
         strcpy(source[ZBSourceColumnUUID], baseSource.uuid.UTF8String);
         
+        NSString *paymentEndpointString = baseSource.paymentEndpointURL.absoluteString;
+        if (paymentEndpointString) strcpy(source[ZBSourceColumnPaymentEndpoint], paymentEndpointString.UTF8String);
+        
+        int supportsFeatured = baseSource.supportsFeaturedPackages;
+        memcpy(source[ZBSourceColumnSupportsFeaturedPackages], &supportsFeatured, 1);
+        
         ZBSource *createdSource = [databaseManager insertSource:source];
         if (createdSource) {
             NSMutableDictionary *tempSourceMap = sourceMap.mutableCopy;

--- a/Zebra/Model/ZBBaseSource.h
+++ b/Zebra/Model/ZBBaseSource.h
@@ -28,9 +28,11 @@ typedef NS_ENUM(NSUInteger, ZBSourceColumn) {
     ZBSourceColumnDistribution,
     ZBSourceColumnLabel,
     ZBSourceColumnOrigin,
+    ZBSourceColumnPaymentEndpoint,
     ZBSourceColumnRemote,
     ZBSourceColumnDescription,
     ZBSourceColumnSuite,
+    ZBSourceColumnSupportsFeaturedPackages,
     ZBSourceColumnURL,
     ZBSourceColumnUUID,
     ZBSourceColumnVersion,
@@ -84,13 +86,19 @@ typedef char *_Nonnull *_Nonnull ZBControlSource;
 @property BOOL packagesTaskCompleted;
 
 /*! @brief Indicates whether or not the task downloading the Release file is completed and the repo should be parsed */
-@property BOOL releaseTaskCompleted;
+@property unsigned int releaseTasksCompleted;
 
 /*! @brief A file path that points to the downloaded Packages file (NULL if no file has been downloaded and the database entry should not be updated) */
 @property NSString *_Nullable packagesFilePath;
 
 /*! @brief A file path that points to the downloaded Release file (NULL if no file has been downloaded and the database entry should not be updated) */
 @property NSString *_Nullable releaseFilePath;
+
+@property (nullable) NSURL *paymentEndpointURL;
+
+@property BOOL supportsFeaturedPackages;
+
+@property NSString *_Nullable featuredPackages;
 
 /*! @brief The base filename of the repository, based on the URL */
 @property (readonly) NSString * _Nullable uuid;

--- a/Zebra/Model/ZBSource.m
+++ b/Zebra/Model/ZBSource.m
@@ -21,9 +21,6 @@
 #import <Managers/ZBSourceManager.h>
 
 @interface ZBSource () {
-    BOOL checkedForPaymentEndpoint;
-    BOOL checkedForFeaturedPackages;
-    NSURL *paymentEndpointURL;
     NSDictionary *featuredPackages;
 }
 @end
@@ -87,7 +84,7 @@
         
         const char *label = (const char *)sqlite3_column_text(statement, ZBSourceColumnLabel);
         if (label) {
-            self.label = [NSString stringWithUTF8String:label]; // This is a variable
+            self.label = [NSString stringWithUTF8String:label];
         }
         
         const char *origin = (const char *)sqlite3_column_text(statement, ZBSourceColumnOrigin);
@@ -95,10 +92,17 @@
             self.origin = [NSString stringWithUTF8String:origin];
         }
         
+        const char *paymentEndpoint = (const char *)sqlite3_column_text(statement, ZBSourceColumnPaymentEndpoint);
+        if (paymentEndpoint) {
+            self.paymentEndpointURL = [NSURL URLWithString:[NSString stringWithUTF8String:paymentEndpoint]];
+        }
+        
         const char *suite = (const char *)sqlite3_column_text(statement, ZBSourceColumnSuite);
         if (suite) {
             _suite = [NSString stringWithUTF8String:suite];
         }
+        
+        self.supportsFeaturedPackages = sqlite3_column_int(statement, ZBSourceColumnSupportsFeaturedPackages);
         
         const char *version = (const char *)sqlite3_column_text(statement, ZBSourceColumnVersion);
         if (version) {
@@ -127,7 +131,7 @@
         return;
     }
     
-    NSURLComponents *components = [NSURLComponents componentsWithURL:[paymentEndpointURL URLByAppendingPathComponent:@"authenticate"] resolvingAgainstBaseURL:YES];
+    NSURLComponents *components = [NSURLComponents componentsWithURL:[self.paymentEndpointURL URLByAppendingPathComponent:@"authenticate"] resolvingAgainstBaseURL:YES];
     if (![components.scheme isEqualToString:@"https"]) {
         NSError *error = [NSError errorWithDomain:NSCocoaErrorDomain code:412 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Source's payment vendor URL is not secure", @"")}];
         completion(NO, YES, error);
@@ -187,7 +191,7 @@
         return;
     }
     
-    NSURL *URL = [paymentEndpointURL URLByAppendingPathComponent:@"sign_out"];
+    NSURL *URL = [self.paymentEndpointURL URLByAppendingPathComponent:@"sign_out"];
     if (!URL || ![URL.scheme isEqualToString:@"https"]) {
 //        NSError *error = [NSError errorWithDomain:NSCocoaErrorDomain code:412 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Source's payment vendor URL is not secure", @"")}];
         return;
@@ -239,14 +243,14 @@
 }
 
 - (BOOL)supportsPaymentAPI {
-    return checkedForPaymentEndpoint && paymentEndpointURL;
+    return self.paymentEndpointURL != NULL;
 }
 
 - (void)getUserInfo:(void (^)(ZBUserInfo *info, NSError *error))completion {
-    if (!paymentEndpointURL || ![self isSignedIn]) return;
+    if (!self.supportsPaymentAPI || ![self isSignedIn]) return;
     
     NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[paymentEndpointURL URLByAppendingPathComponent:@"user_info"]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[self.paymentEndpointURL URLByAppendingPathComponent:@"user_info"]];
     
     UICKeyChainStore *keychain = [UICKeyChainStore keyChainStoreWithService:[ZBAppDelegate bundleID] accessGroup:nil];
     
@@ -284,10 +288,10 @@
 }
 
 - (void)getSourceInfo:(void (^)(ZBSourceInfo *info, NSError *error))completion {
-    if (!paymentEndpointURL) return;
+    if (!self.paymentEndpointURL) return;
     
     NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[paymentEndpointURL URLByAppendingPathComponent:@"info"]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[self.paymentEndpointURL URLByAppendingPathComponent:@"info"]];
     
     [request setHTTPMethod:@"GET"];
     [request setValue:[NSString stringWithFormat:@"Zebra/%@ (%@; iOS/%@)", PACKAGE_VERSION, [ZBDevice deviceType], [[UIDevice currentDevice] systemVersion]] forHTTPHeaderField:@"User-Agent"];
@@ -321,31 +325,31 @@
     else return _pinPriority;
 }
 
-- (void)getPaymentEndpoint:(void (^)(NSURL *))completion {
-    if (checkedForPaymentEndpoint) completion(paymentEndpointURL);
-    
-    [[NSURLSession sharedSession] dataTaskWithURL:[self.mainDirectoryURL URLByAppendingPathComponent:@"payment_endpoint"] completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
-        NSInteger httpStatus = [((NSHTTPURLResponse *)response) statusCode];
-        if (httpStatus == 200 && !error) {
-            NSString *response = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-            if (response) {
-                self->paymentEndpointURL = [NSURL URLWithString:response];
-            }
-        }
-        self->checkedForPaymentEndpoint = YES;
-        completion(self->paymentEndpointURL);
-    }];
-}
+//- (void)getPaymentEndpoint:(void (^)(NSURL *))completion {
+//    if (checkedForPaymentEndpoint) completion(paymentEndpointURL);
+//
+//    [[NSURLSession sharedSession] dataTaskWithURL:[self.mainDirectoryURL URLByAppendingPathComponent:@"payment_endpoint"] completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+//        NSInteger httpStatus = [((NSHTTPURLResponse *)response) statusCode];
+//        if (httpStatus == 200 && !error) {
+//            NSString *response = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+//            if (response) {
+//                self->paymentEndpointURL = [NSURL URLWithString:response];
+//            }
+//        }
+//        self->checkedForPaymentEndpoint = YES;
+//        completion(self->paymentEndpointURL);
+//    }];
+//}
 
 - (void)getFeaturedPackages:(void (^)(NSDictionary *))completion {
-    if (checkedForFeaturedPackages) completion(featuredPackages);
+    if (self->featuredPackages) completion(featuredPackages);
+    if (!self.supportsFeaturedPackages) completion(NULL);
     
     [[NSURLSession sharedSession] dataTaskWithURL:[self.mainDirectoryURL URLByAppendingPathComponent:@"sileo-featured.json"] completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
         NSInteger httpStatus = [((NSHTTPURLResponse *)response) statusCode];
         if (httpStatus == 200 && !error) {
             self->featuredPackages = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:nil];
         }
-        self->checkedForFeaturedPackages = YES;
         completion(self->featuredPackages);
     }];
 }

--- a/Zebra/Model/ZBSource.m
+++ b/Zebra/Model/ZBSource.m
@@ -94,7 +94,8 @@
         
         const char *paymentEndpoint = (const char *)sqlite3_column_text(statement, ZBSourceColumnPaymentEndpoint);
         if (paymentEndpoint) {
-            self.paymentEndpointURL = [NSURL URLWithString:[NSString stringWithUTF8String:paymentEndpoint]];
+            NSURL *endpointURL = [NSURL URLWithString:[NSString stringWithUTF8String:paymentEndpoint]];
+            if ([endpointURL.scheme isEqual:@"https"]) self.paymentEndpointURL = endpointURL;
         }
         
         const char *suite = (const char *)sqlite3_column_text(statement, ZBSourceColumnSuite);

--- a/Zebra/Tabs/Sources/Views/ZBSourcesAccountBanner.m
+++ b/Zebra/Tabs/Sources/Views/ZBSourcesAccountBanner.m
@@ -8,11 +8,12 @@
 
 #import "ZBSourcesAccountBanner.h"
 #import "UIColor+GlobalColors.h"
-//#import <Tabs/Sources/Helpers/ZBSource.h>
 #import <JSONParsing/ZBSourceInfo.h>
 #import <JSONParsing/ZBUserInfo.h>
 #import <ZBAppDelegate.h>
 #import "ZBSourceSectionsListTableViewController.h"
+
+#import <Model/ZBSource.h>
 
 @interface ZBSourcesAccountBanner () {
     BOOL hideUDID;
@@ -29,13 +30,13 @@
     self = [[[NSBundle mainBundle] loadNibNamed:NSStringFromClass([self class]) owner:self options:nil] objectAtIndex:0];
     self.source = source;
     self.owner = owner;
-//    [self.source getSourceInfo:^(ZBSourceInfo * _Nonnull info, NSError * _Nonnull error) {
-//        if (info && !error) {
-//            self.sourceInfo = info;
-//        }
-//        
-//        [self updateText];
-//    }];
+    [self.source getSourceInfo:^(ZBSourceInfo * _Nonnull info, NSError * _Nonnull error) {
+        if (info && !error) {
+            self.sourceInfo = info;
+        }
+        
+        [self updateText];
+    }];
     
     [self.button addTarget:owner action:@selector(accountButtonPressed:) forControlEvents:UIControlEventTouchDown];
     
@@ -73,33 +74,33 @@
 - (void)updateText {
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.activityIndicatorView startAnimating];
-//        if ([self->source isSignedIn]) {
-//            [self.button setTitle:NSLocalizedString(@"My Account", @"") forState:UIControlStateNormal];
-//            [self->source getUserInfo:^(ZBUserInfo * _Nonnull info, NSError * _Nonnull error) {
-//                dispatch_async(dispatch_get_main_queue(), ^{
-//                    if (info && !error) {
-//                        if (self->hideEmail) {
-//                            self.descriptionLabel.text = [NSString stringWithFormat:NSLocalizedString(@"Signed in as %@", @""), info.user.name];
-//                        }
-//                        else {
-//                            self.descriptionLabel.text = [NSString stringWithFormat:NSLocalizedString(@"Signed in as %@ (%@)", @""), info.user.name, info.user.email];
-//                        }
-//                    }
-//                    else {
-//                        self.descriptionLabel.text = NSLocalizedString(@"An Error Occurred", @"");
-//                    }
-//                    [self.activityIndicatorView stopAnimating];
-//                });
-//            }];
-//        } else {
-//            [self.button setTitle:NSLocalizedString(@"Sign In", @"") forState:UIControlStateNormal];
-//            if (self->sourceInfo) {
-//                self.descriptionLabel.text = self->sourceInfo.authenticationBanner.message;
-//            } else {
-//                self.descriptionLabel.text = NSLocalizedString(@"An Error Occurred", @"");
-//            }
-//            [self.activityIndicatorView stopAnimating];
-//        }
+        if ([self->source isSignedIn]) {
+            [self.button setTitle:NSLocalizedString(@"My Account", @"") forState:UIControlStateNormal];
+            [self->source getUserInfo:^(ZBUserInfo * _Nonnull info, NSError * _Nonnull error) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    if (info && !error) {
+                        if (self->hideEmail) {
+                            self.descriptionLabel.text = [NSString stringWithFormat:NSLocalizedString(@"Signed in as %@", @""), info.user.name];
+                        }
+                        else {
+                            self.descriptionLabel.text = [NSString stringWithFormat:NSLocalizedString(@"Signed in as %@ (%@)", @""), info.user.name, info.user.email];
+                        }
+                    }
+                    else {
+                        self.descriptionLabel.text = NSLocalizedString(@"An Error Occurred", @"");
+                    }
+                    [self.activityIndicatorView stopAnimating];
+                });
+            }];
+        } else {
+            [self.button setTitle:NSLocalizedString(@"Sign In", @"") forState:UIControlStateNormal];
+            if (self->sourceInfo) {
+                self.descriptionLabel.text = self->sourceInfo.authenticationBanner.message;
+            } else {
+                self.descriptionLabel.text = NSLocalizedString(@"An Error Occurred", @"");
+            }
+            [self.activityIndicatorView stopAnimating];
+        }
     });
 }
 


### PR DESCRIPTION
This PR reimplements and improves the payment API implementation in Zebra by coupling the payment endpoint and featured packages download into the `Release` download that is performed every source refresh. For the payment API, we query the `payment_endpoint` URL for sources that have secure schemes and save the result into the database if there is a payment endpoint available. For featured packages, we simply query the `sileo-featured.json` URL for sources and if there is a file on the other end, we store that the repository supports featured packages in the database for use later.

This is an improvement over the previous implementation where payment endpoints were queried asynchronously with the source refresh which could result in sources having a payment endpoint in the database, but it wasn't visible within Zebra because it was found *after* the source had already been loaded. Now, sources are not finished loading until a response is received from the payment endpoint. Featured packages capability was also queried once per opening the app, now they are queried once per source refresh.