### PR TITLE
[Package] Improved listing of dependencies

### DIFF
--- a/Zebra/Model/ZBPackage.m
+++ b/Zebra/Model/ZBPackage.m
@@ -162,8 +162,12 @@
         
         const char *depends = (const char *)sqlite3_column_text(statement, ZBPackageColumnDepends);
         if (depends && depends[0] != '\0') {
+            NSMutableArray <NSString *> *normalizedDepends = [NSMutableArray array];
             NSString *rawDepends = [NSString stringWithUTF8String:depends];
-            _depends = [rawDepends componentsSeparatedByString:@","];
+            for (NSString *depend in [rawDepends componentsSeparatedByString:@","]) {
+                [normalizedDepends addObject:[depend stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]]];
+            }
+            _depends = normalizedDepends.copy;
         }
         
         const char *depictionURL = (const char *)sqlite3_column_text(statement, ZBPackageColumnDepictionURL);
@@ -768,16 +772,7 @@ NSComparisonResult (^versionComparator)(NSString *, NSString *) = ^NSComparisonR
         for (NSString *depend in self.depends) {
             if ([depend containsString:@" | "]) {
                 NSArray *ord = [depend componentsSeparatedByString:@" | "];
-                for (__strong NSString *conflict in ord) {
-                    NSRange range = [conflict rangeOfString:@"("];
-                    if (range.location != NSNotFound) {
-                        conflict = [conflict substringToIndex:range.location];
-                    }
-                    
-                    if (![strippedDepends containsObject:conflict]) {
-                        [strippedDepends addObject:conflict];
-                    }
-                }
+                [strippedDepends addObject:[ord componentsJoinedByString:@" or "]];
             }
             else if (![strippedDepends containsObject:depend]) {
                 [strippedDepends addObject:depend];


### PR DESCRIPTION
The current logic of extracting dependencies from `Depends` line doesn't look correct to me. See this example.

![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-12-28 at 19 19 03](https://user-images.githubusercontent.com/3608783/103213932-ba2ac880-4941-11eb-9329-31df49ad20dd.png)

`firmware` alone is not a correct dependency to be listed. After carefully checking the code, I learned that `depends` property of `ZBPackage` may contain leading and/or trailing spaces. I had to strip those whitespaces about during creation of `depends` property.

Additionally, for those dependencies interconnected with `|` operator, it would be more human readable by joining them with ` or ` as you can see below:

![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-12-28 at 19 07 37](https://user-images.githubusercontent.com/3608783/103214148-463cf000-4942-11eb-98d5-74f3b7eb6cd9.png)

Here's an example from another package that has more dependencies, with the new logic applied:

![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-12-28 at 19 08 22](https://user-images.githubusercontent.com/3608783/103214178-5ce34700-4942-11eb-8a20-e9f3a13442a2.png)
