### PR TITLE
[Packages] Display all packages in a corresponding section when there is no search query

### DIFF
--- a/Zebra/Managers/ZBPackageManager.m
+++ b/Zebra/Managers/ZBPackageManager.m
@@ -283,7 +283,7 @@
 }
 
 - (NSArray <ZBPackage *> *)filterPackages:(NSArray <ZBPackage *> *)packages withFilter:(ZBPackageFilter *)filter {
-    if (!filter || filter.searchTerm.length == 0) return packages;
+    if (!filter) return packages;
     
     NSArray *filteredPackages = [packages filteredArrayUsingPredicate:filter.compoundPredicate];
     return [filteredPackages sortedArrayUsingDescriptors:filter.sortDescriptors];

--- a/Zebra/Managers/ZBPackageManager.m
+++ b/Zebra/Managers/ZBPackageManager.m
@@ -283,7 +283,7 @@
 }
 
 - (NSArray <ZBPackage *> *)filterPackages:(NSArray <ZBPackage *> *)packages withFilter:(ZBPackageFilter *)filter {
-    if (!filter) return packages;
+    if (!filter || filter.searchTerm.length == 0) return packages;
     
     NSArray *filteredPackages = [packages filteredArrayUsingPredicate:filter.compoundPredicate];
     return [filteredPackages sortedArrayUsingDescriptors:filter.sortDescriptors];

--- a/Zebra/Model/ZBPackageFilter.m
+++ b/Zebra/Model/ZBPackageFilter.m
@@ -84,8 +84,10 @@
         [predicates addObject:sectionPredicate];
     }
     
-    NSPredicate *rolePredicate = [NSPredicate predicateWithFormat:@"role <= %d", _role];
-    [predicates addObject:rolePredicate];
+    if (_searchTerm && _searchTerm.length) {
+        NSPredicate *rolePredicate = [NSPredicate predicateWithFormat:@"role <= %d", _role];
+        [predicates addObject:rolePredicate];
+    }
 
     if (_commercial) {
         NSPredicate *commercialPredicate = [NSPredicate predicateWithFormat:@"isPaid == YES"];

--- a/Zebra/Model/ZBPackageFilter.m
+++ b/Zebra/Model/ZBPackageFilter.m
@@ -74,7 +74,7 @@
 - (NSCompoundPredicate *)compoundPredicate {
     NSMutableArray *predicates = [NSMutableArray new];
     
-    if (_searchTerm) {
+    if (_searchTerm && _searchTerm.length) {
         NSPredicate *searchPredicate = [NSPredicate predicateWithFormat:@"name contains[cd] %@", _searchTerm];
         [predicates addObject:searchPredicate];
     }

--- a/Zebra/Model/ZBPackageFilter.m
+++ b/Zebra/Model/ZBPackageFilter.m
@@ -84,10 +84,8 @@
         [predicates addObject:sectionPredicate];
     }
     
-    if (_searchTerm && _searchTerm.length) {
-        NSPredicate *rolePredicate = [NSPredicate predicateWithFormat:@"role <= %d", _role];
-        [predicates addObject:rolePredicate];
-    }
+    NSPredicate *rolePredicate = [NSPredicate predicateWithFormat:@"role <= %d", _role];
+    [predicates addObject:rolePredicate];
 
     if (_commercial) {
         NSPredicate *commercialPredicate = [NSPredicate predicateWithFormat:@"isPaid == YES"];

--- a/Zebra/UI/Packages/ZBPackageListViewController.m
+++ b/Zebra/UI/Packages/ZBPackageListViewController.m
@@ -26,7 +26,7 @@
     ZBPackageManager *packageManager;
     UISearchController *searchController;
     UIActivityIndicatorView *spinner;
-    NSArray *filterResults;
+    NSArray <ZBPackage *> *filterResults;
     NSArray *updates;
 }
 @property (nonnull) ZBPackageFilter *filter;
@@ -124,7 +124,7 @@
     [self showSpinner];
     if (_packages) {
         dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-            NSArray *filteredPackages = [self->packageManager filterPackages:self.packages withFilter:self.filter];
+            NSArray <ZBPackage *> *filteredPackages = [self->packageManager filterPackages:self->_packages withFilter:self.filter];
             dispatch_async(dispatch_get_main_queue(), ^{
                 [self hideSpinner];
                 self->filterResults = filteredPackages;


### PR DESCRIPTION
Currently, if you try to view the packages from a section: Go to Sources tab > Choose any source > Choose any section that is not "All Packages", all you see is a blank page. This is because `-[ZBPackageManager filterPackages:withFilter:]` would respect `filter`'s `compoundPredicate` and return empty results as `[NSPredicate predicateWithFormat:@"name contains[cd] %@", _searchTerm];` would always yield false.

This PR only applies search term predicate when the search term is not empty.

![image](https://user-images.githubusercontent.com/3608783/103327923-485d9680-4a89-11eb-80f0-754eeee4ae1a.png)