### PR TITLE
Synchronize database transactions

### DIFF
--- a/Zebra/Managers/ZBDatabaseManager.m
+++ b/Zebra/Managers/ZBDatabaseManager.m
@@ -111,30 +111,30 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
 
 - (BOOL)connectToDatabase {
     BOOL ret = YES;
-    ZBLog(@"[Zebra] Initializing database at %@", databasePath);
+    ZBLog(@"[Zebra] Initializing database at %s", databasePath);
     
     int result = [self openDatabase];
     if (result != SQLITE_OK) {
-        ZBLog(@"[Zebra] Failed to open database at %@", databasePath);
+        ZBLog(@"[Zebra] Failed to open database at %s", databasePath);
     }
     
     if (![self needsMigration]) {
         if (result == SQLITE_OK) {
             result = sqlite3_create_function(database, "maxversion", 1, SQLITE_UTF8, NULL, NULL, maxVersionStep, maxVersionFinal);
             if (result != SQLITE_OK) {
-                ZBLog(@"[Zebra] Failed to create aggregate function at %@", databasePath);
+                ZBLog(@"[Zebra] Failed to create aggregate function at %s", databasePath);
             }
         }
         
         if (result == SQLITE_OK) {
             result = [self initializePreparedStatements];
             if (result != SQLITE_OK) {
-                ZBLog(@"[Zebra] Failed to initialize prepared statements at %@", databasePath);
+                ZBLog(@"[Zebra] Failed to initialize prepared statements at %s", databasePath);
             }
         }
         
         if (result != SQLITE_OK) {
-            ZBLog(@"[Zebra] Failed to initialize database at %@", databasePath);
+            ZBLog(@"[Zebra] Failed to initialize database at %s", databasePath);
             ret = NO;
         }
     } else {
@@ -194,7 +194,7 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
         }
     }
     sqlite3_finalize(statement);
-    ZBLog(@"[Zebra] Current Schema Version: %d", ret);
+    ZBLog(@"[Zebra] Current Schema Version: %d", schemaVersion);
     return schemaVersion;
 }
 
@@ -483,7 +483,7 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
         } while (result == SQLITE_ROW);
             
         if (result != SQLITE_DONE) {
-            ZBLog(@"[Zebra] Failed to query packages from %@ with error %d (%s, %d)", source.uuid, result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+            ZBLog(@"[Zebra] Failed to query packages from %@ with error %d (%s, %d)", source.uuid, result, sqlite3_errmsg(self->database), sqlite3_extended_errcode(self->database));
         }
     }];
 
@@ -641,7 +641,7 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
         } while (result == SQLITE_ROW);
         
         if (result != SQLITE_DONE) {
-            ZBLog(@"[Zebra] Failed to query packages by author with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+            ZBLog(@"[Zebra] Failed to query packages by author with error %d (%s, %d)", result, sqlite3_errmsg(self->database), sqlite3_extended_errcode(self->database));
         }
     }];
     sqlite3_finalize(statement);
@@ -672,7 +672,7 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
         } while (result == SQLITE_ROW);
         
         if (result != SQLITE_DONE) {
-            ZBLog(@"[Zebra] Failed to query latest packages with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+            ZBLog(@"[Zebra] Failed to query latest packages with error %d (%s, %d)", result, sqlite3_errmsg(self->database), sqlite3_extended_errcode(self->database));
         }
     }];
     
@@ -704,7 +704,7 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
         } while (result == SQLITE_ROW);
         
         if (result != SQLITE_DONE) {
-            ZBLog(@"[Zebra] Failed to query packages from identifiers with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+            ZBLog(@"[Zebra] Failed to query packages from identifiers with error %d (%s, %d)", result, sqlite3_errmsg(self->database), sqlite3_extended_errcode(self->database));
         }
     }];
     
@@ -754,7 +754,7 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
         } while (result == SQLITE_ROW);
         
         if (result != SQLITE_DONE && result != SQLITE_OK) {
-            ZBLog(@"[Zebra] Failed to get all versions of package with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+            ZBLog(@"[Zebra] Failed to get all versions of package with error %d (%s, %d)", result, sqlite3_errmsg(self->database), sqlite3_extended_errcode(self->database));
         }
     }];
         
@@ -780,7 +780,7 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
         } while (result == SQLITE_ROW);
         
         if (result != SQLITE_DONE && result != SQLITE_OK) {
-            ZBLog(@"[Zebra] Failed to get all instances of package with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+            ZBLog(@"[Zebra] Failed to get all instances of package with error %d (%s, %d)", result, sqlite3_errmsg(self->database), sqlite3_extended_errcode(self->database));
         }
     }];
         
@@ -1105,7 +1105,7 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
         } while (result == SQLITE_ROW);
         
         if (result != SQLITE_DONE) {
-            ZBLog(@"[Zebra] Failed to query package uuids from %@ with error %d (%s, %d)", source.uuid, result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+            ZBLog(@"[Zebra] Failed to query package uuids from %@ with error %d (%s, %d)", source.uuid, result, sqlite3_errmsg(self->database), sqlite3_extended_errcode(self->database));
         }
     }];
 
@@ -1157,7 +1157,7 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
         } while (result == SQLITE_ROW);
         
         if (result != SQLITE_DONE) {
-            ZBLog(@"[Zebra] Failed to query section readout with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+            ZBLog(@"[Zebra] Failed to query section readout with error %d (%s, %d)", result, sqlite3_errmsg(self->database), sqlite3_extended_errcode(self->database));
         }
     }];
             
@@ -1293,7 +1293,7 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
             if (result == SQLITE_OK) {
                 result = sqlite3_step(statement);
                 if (result != SQLITE_DONE) {
-                    ZBLog(@"[Zebra] Failed to delete package with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+                    ZBLog(@"[Zebra] Failed to delete package with error %d (%s, %d)", result, sqlite3_errmsg(self->database), sqlite3_extended_errcode(self->database));
                 }
             }
             sqlite3_clear_bindings(statement);

--- a/Zebra/Managers/ZBDatabaseManager.m
+++ b/Zebra/Managers/ZBDatabaseManager.m
@@ -424,6 +424,8 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
         int result = sqlite3_prepare(database, statementString, -1, &statement, NULL);
         if (result != SQLITE_OK) {
             ZBLog(@"[Zebra] Failed to prepare sqlite statement %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+        } else {
+            preparedStatements[statementType] = statement;
         }
     }
     return statement;

--- a/Zebra/Managers/ZBDatabaseManager.m
+++ b/Zebra/Managers/ZBDatabaseManager.m
@@ -60,9 +60,9 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
 
 @interface ZBDatabaseManager () {
     sqlite3 *database;
-    NSString *databasePath;
+    const char *databasePath;
     sqlite3_stmt **preparedStatements;
-    dispatch_queue_t databaseQueue;
+    dispatch_queue_t searchQueue;
     dispatch_block_t currentSearchBlock;
 }
 @end
@@ -88,10 +88,10 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
     self = [super init];
     
     if (self) {
-        databasePath = path;
+        databasePath = path.UTF8String;
         
         dispatch_queue_attr_t attributes = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_CONCURRENT, QOS_CLASS_BACKGROUND, 0);
-        databaseQueue = dispatch_queue_create("xyz.willy.Zebra.database", attributes);
+        searchQueue = dispatch_queue_create("xyz.willy.Zebra.search", attributes);
         
         if (![self connectToDatabase]) {
             return nil;
@@ -110,78 +110,68 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
 #pragma mark - Opening and Closing the Database
 
 - (BOOL)connectToDatabase {
-    __block BOOL ret = YES;
-    dispatch_sync(databaseQueue, ^{
-        ZBLog(@"[Zebra] Initializing database at %@", databasePath);
-
-        int result = [self openDatabase];
-        if (result != SQLITE_OK) {
-            ZBLog(@"[Zebra] Failed to open database at %@", databasePath);
+    BOOL ret = YES;
+    ZBLog(@"[Zebra] Initializing database at %@", databasePath);
+    
+    int result = [self openDatabase];
+    if (result != SQLITE_OK) {
+        ZBLog(@"[Zebra] Failed to open database at %@", databasePath);
+    }
+    
+    if (![self needsMigration]) {
+        if (result == SQLITE_OK) {
+            result = sqlite3_create_function(database, "maxversion", 1, SQLITE_UTF8, NULL, NULL, maxVersionStep, maxVersionFinal);
+            if (result != SQLITE_OK) {
+                ZBLog(@"[Zebra] Failed to create aggregate function at %@", databasePath);
+            }
         }
         
-        if (![self needsMigration]) {
-            if (result == SQLITE_OK) {
-                result = sqlite3_create_function(database, "maxversion", 1, SQLITE_UTF8, NULL, NULL, maxVersionStep, maxVersionFinal);
-                if (result != SQLITE_OK) {
-                    ZBLog(@"[Zebra] Failed to create aggregate function at %@", databasePath);
-                }
-            }
-            
-            if (result == SQLITE_OK) {
-                result = [self initializePreparedStatements];
-                if (result != SQLITE_OK) {
-                    ZBLog(@"[Zebra] Failed to initialize prepared statements at %@", databasePath);
-                }
-            }
-
+        if (result == SQLITE_OK) {
+            result = [self initializePreparedStatements];
             if (result != SQLITE_OK) {
-                ZBLog(@"[Zebra] Failed to initialize database at %@", databasePath);
-                ret = NO;
+                ZBLog(@"[Zebra] Failed to initialize prepared statements at %@", databasePath);
             }
-        } else {
-            ZBLog(@"[Zebra] Database needs migration, not continuing.");
         }
-    });
-
+        
+        if (result != SQLITE_OK) {
+            ZBLog(@"[Zebra] Failed to initialize database at %@", databasePath);
+            ret = NO;
+        }
+    } else {
+        ZBLog(@"[Zebra] Database needs migration, not continuing.");
+    }
     return ret;
 }
 
 - (void)disconnectFromDatabase {
-    dispatch_sync(databaseQueue, ^{
-        if (preparedStatements) {
-            for (unsigned int i = 0; i < ZBDatabaseStatementTypeCount; i++) {
-                sqlite3_finalize(preparedStatements[i]);
-            }
-            free(preparedStatements);
-            preparedStatements = NULL;
+    if (preparedStatements) {
+        for (unsigned int i = 0; i < ZBDatabaseStatementTypeCount; i++) {
+            sqlite3_stmt *statement = preparedStatements[i];
+            if (statement) sqlite3_finalize(statement);
         }
-        [self closeDatabase];
-    });
+        free(preparedStatements);
+        preparedStatements = NULL;
+    }
+    [self closeDatabase];
 }
 
 - (int)openDatabase {
-    __block int result = SQLITE_ERROR;
-    dispatch_sync(databaseQueue, ^{
-        int flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FILEPROTECTION_COMPLETEUNLESSOPEN | SQLITE_OPEN_FULLMUTEX;
-        result = sqlite3_open_v2(databasePath.UTF8String, &database, flags, NULL);
-    });
-    return result;
+    int flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FILEPROTECTION_COMPLETEUNLESSOPEN | SQLITE_OPEN_FULLMUTEX;
+    return sqlite3_open_v2(databasePath, &database, flags, NULL);
 }
 
 - (int)closeDatabase {
-    __block int result = SQLITE_ERROR;
-    dispatch_sync(databaseQueue, ^{
-        if (database) {
-            result = sqlite3_close(database);
-            if (result == SQLITE_OK) {
-                database = NULL;
-            } else {
-                NSLog(@"[Zebra] Failed to close database path: %@", databasePath);
-            }
+    int result = SQLITE_ERROR;
+    if (database) {
+        result = sqlite3_close(database);
+        if (result == SQLITE_OK) {
+            database = NULL;
         } else {
-            NSLog(@"[Zebra] Attempt to close null database handle");
+            NSLog(@"[Zebra] Failed to close database path: %s", databasePath);
         }
-    });
+    } else {
+        NSLog(@"[Zebra] Attempt to close null database handle");
+    }
     return result;
 }
 
@@ -192,30 +182,27 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
 }
 
 - (int)schemaVersion {
-    __block int ret = 0;
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement;
-        const char *query = "PRAGMA user_version;";
+    sqlite3_stmt *statement;
+    const char *query = "PRAGMA user_version;";
     
-        int result = sqlite3_prepare_v2(database, query, -1, &statement, nil);
-        if (result == SQLITE_OK) {
-            result = sqlite3_step(statement);
-            if (result == SQLITE_ROW) {
-                ret = sqlite3_column_int(statement, 0);
-            }
+    int schemaVersion = 0;
+    int result = sqlite3_prepare_v2(database, query, -1, &statement, nil);
+    if (result == SQLITE_OK) {
+        result = sqlite3_step(statement);
+        if (result == SQLITE_ROW) {
+            schemaVersion = sqlite3_column_int(statement, 0);
         }
-        sqlite3_finalize(statement);
-    });
+    }
+    sqlite3_finalize(statement);
     ZBLog(@"[Zebra] Current Schema Version: %d", ret);
-    return ret;
+    return schemaVersion;
 }
 
 - (void)setSchemaVersion {
     ZBLog(@"[Zebra] Setting Schema Version to %d", DATABASE_VERSION);
-    dispatch_sync(databaseQueue, ^{
-        NSString *query = [NSString stringWithFormat:@"PRAGMA user_version = %d;", DATABASE_VERSION];
-        sqlite3_exec(database, query.UTF8String, nil, nil, nil);
-    });
+    
+    NSString *query = [NSString stringWithFormat:@"PRAGMA user_version = %d;", DATABASE_VERSION];
+    sqlite3_exec(database, query.UTF8String, nil, nil, nil);
 }
 
 - (void)migrateDatabase {
@@ -224,60 +211,57 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
     
     ZBLog(@"[Zebra] Migrating database from version %d to %d", version, DATABASE_VERSION);
     
-    dispatch_sync(databaseQueue, ^{
-        [self beginTransaction];
-        switch (version + 1) {
-            case 1: {
-                // First major DB revision, we need to migration ignore update preferences and likely drop everything else due to the size of the changes.
-                
-                // Drop old PACKAGES and REPOS tables. We can easily recover the data with a source refresh.
-                sqlite3_exec(self->database, "DROP TABLE PACKAGES;", nil, nil, nil);
-                sqlite3_exec(self->database, "DROP TABLE REPOS;", nil, nil, nil);
-                
-                // Transfer updates from old UPDATES table to NSUserDefaults
-                sqlite3_stmt *statement;
-                const char *query = "SELECT PACKAGE FROM UPDATES WHERE IGNORE = 1;";
-                int result = sqlite3_prepare_v2(self->database, query, -1, &statement, nil);
-                if (result == SQLITE_OK) {
-                    do {
-                        result = sqlite3_step(statement);
-                        if (result == SQLITE_ROW) {
-                            const char *identifier = (const char *)sqlite3_column_text(statement, 0);
-                            if (identifier) {
-                                [ZBSettings setUpdatesIgnored:YES forPackageIdentifier:[NSString stringWithUTF8String:identifier]];
-                            }
+    [self beginTransaction];
+    switch (version + 1) {
+        case 1: {
+            // First major DB revision, we need to migration ignore update preferences and likely drop everything else due to the size of the changes.
+            
+            // Drop old PACKAGES and REPOS tables. We can easily recover the data with a source refresh.
+            sqlite3_exec(self->database, "DROP TABLE PACKAGES;", nil, nil, nil);
+            sqlite3_exec(self->database, "DROP TABLE REPOS;", nil, nil, nil);
+            
+            // Transfer updates from old UPDATES table to NSUserDefaults
+            sqlite3_stmt *statement;
+            const char *query = "SELECT PACKAGE FROM UPDATES WHERE IGNORE = 1;";
+            int result = sqlite3_prepare_v2(self->database, query, -1, &statement, nil);
+            if (result == SQLITE_OK) {
+                do {
+                    result = sqlite3_step(statement);
+                    if (result == SQLITE_ROW) {
+                        const char *identifier = (const char *)sqlite3_column_text(statement, 0);
+                        if (identifier) {
+                            [ZBSettings setUpdatesIgnored:YES forPackageIdentifier:[NSString stringWithUTF8String:identifier]];
                         }
-                    } while (result == SQLITE_ROW);
-                }
-                
-                sqlite3_finalize(statement);
-                
-                // Drop old UPDATES table. Updates aren't store separately anymore.
-                sqlite3_exec(self->database, "DROP TABLE UPDATES;", nil, nil, nil);
-                
-                // Create new tables
-                result = [self initializePackagesTable];
-                result = [self initializeSourcesTable];
-                
-                break;
+                    }
+                } while (result == SQLITE_ROW);
             }
+            
+            sqlite3_finalize(statement);
+            
+            // Drop old UPDATES table. Updates aren't store separately anymore.
+            sqlite3_exec(self->database, "DROP TABLE UPDATES;", nil, nil, nil);
+            
+            // Create new tables
+            result = [self initializePackagesTable];
+            result = [self initializeSourcesTable];
+            
+            break;
         }
-
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"lastUpdated"];
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"lastUpdatedStatusDate"];
-        [self setSchemaVersion];
-        [self endTransaction];
-        [self disconnectFromDatabase];
-        [self connectToDatabase];
-    });
+    }
+    
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"lastUpdated"];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"lastUpdatedStatusDate"];
+    [self setSchemaVersion];
+    [self endTransaction];
+    [self disconnectFromDatabase];
+    [self connectToDatabase];
 }
 
 #pragma mark - Creating Tables
 
 - (int)initializePackagesTable {
-    __block int result = SQLITE_ERROR;
-    dispatch_sync(databaseQueue, ^{
-        NSString *createTableStatement = @"CREATE TABLE IF NOT EXISTS " PACKAGES_TABLE_NAME
+    int result = SQLITE_ERROR;
+    NSString *createTableStatement = @"CREATE TABLE IF NOT EXISTS " PACKAGES_TABLE_NAME
                                           "(authorName TEXT, "
                                           "description TEXT, "
                                           "downloadSize INTEGER, "
@@ -308,26 +292,24 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
                                           "sha256 TEXT, "
                                           "PRIMARY KEY(uuid)) "
                                           "WITHOUT ROWID;";
-        result = sqlite3_exec(database, [createTableStatement UTF8String], NULL, NULL, NULL);
-        if (result != SQLITE_OK) {
-            ZBLog(@"[Zebra] Failed to create packages table with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
-        }
+    result = sqlite3_exec(database, [createTableStatement UTF8String], NULL, NULL, NULL);
+    if (result != SQLITE_OK) {
+        ZBLog(@"[Zebra] Failed to create packages table with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+    }
 
-        if (result == SQLITE_OK) {
-            NSString *createIndexStatement = @"CREATE INDEX IF NOT EXISTS uuid ON " PACKAGES_TABLE_NAME "(uuid);";
-            result = sqlite3_exec(database, [createIndexStatement UTF8String], NULL, NULL, NULL);
-            if (result != SQLITE_OK) {
-                ZBLog(@"[Zebra] Failed to create uuid index on packages table with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
-            }
+    if (result == SQLITE_OK) {
+        NSString *createIndexStatement = @"CREATE INDEX IF NOT EXISTS uuid ON " PACKAGES_TABLE_NAME "(uuid);";
+        result = sqlite3_exec(database, [createIndexStatement UTF8String], NULL, NULL, NULL);
+        if (result != SQLITE_OK) {
+            ZBLog(@"[Zebra] Failed to create uuid index on packages table with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
         }
-    });
+    }
     return result;
 }
 
 - (int)initializeSourcesTable {
-    __block int result = SQLITE_ERROR;
-    dispatch_sync(databaseQueue, ^{
-        NSString *createTableStatement = @"CREATE TABLE IF NOT EXISTS " SOURCES_TABLE_NAME
+    int result = SQLITE_ERROR;
+    NSString *createTableStatement = @"CREATE TABLE IF NOT EXISTS " SOURCES_TABLE_NAME
                                           "(architectures TEXT, "
                                           "archiveType TEXT, "
                                           "codename TEXT, "
@@ -344,19 +326,18 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
                                           "version TEXT, "
                                           "PRIMARY KEY(uuid)) "
                                           "WITHOUT ROWID;";
-        result = sqlite3_exec(database, [createTableStatement UTF8String], NULL, NULL, NULL);
-        if (result != SQLITE_OK) {
-            ZBLog(@"[Zebra] Failed to create sources table with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
-        }
+    result = sqlite3_exec(database, [createTableStatement UTF8String], NULL, NULL, NULL);
+    if (result != SQLITE_OK) {
+        ZBLog(@"[Zebra] Failed to create sources table with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+    }
 
-        if (result == SQLITE_OK) {
-            NSString *createIndexStatement = @"CREATE INDEX IF NOT EXISTS uuid ON " SOURCES_TABLE_NAME "(uuid);";
-            result = sqlite3_exec(database, [createIndexStatement UTF8String], NULL, NULL, NULL);
-            if (result != SQLITE_OK) {
-                ZBLog(@"[Zebra] Failed to create uuid index on sources table with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
-            }
+    if (result == SQLITE_OK) {
+        NSString *createIndexStatement = @"CREATE INDEX IF NOT EXISTS uuid ON " SOURCES_TABLE_NAME "(uuid);";
+        result = sqlite3_exec(database, [createIndexStatement UTF8String], NULL, NULL, NULL);
+        if (result != SQLITE_OK) {
+            ZBLog(@"[Zebra] Failed to create uuid index on sources table with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
         }
-    });
+    }
     return result;
 }
 
@@ -424,515 +405,460 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
 }
 
 - (sqlite3_stmt *)preparedStatementOfType:(ZBDatabaseStatementType)statementType {
-    __block sqlite3_stmt *statement;
-    dispatch_sync(databaseQueue, ^{
-        statement = preparedStatements[statementType];
-        sqlite3_reset(statement);
-    });
+    sqlite3_stmt *statement = preparedStatements[statementType];
+    if (!statement) {
+        const char *statementString = [self statementStringForStatementType:statementType].UTF8String;
+        int result = sqlite3_prepare(database, statementString, -1, &statement, NULL);
+        if (result != SQLITE_OK) {
+            ZBLog(@"[Zebra] Failed to prepare sqlite statement %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+        }
+    }
     return statement;
 }
 
 - (int)initializePreparedStatements {
-    __block int result = SQLITE_OK;
-    dispatch_sync(databaseQueue, ^{
-        preparedStatements = (sqlite3_stmt **) malloc(sizeof(sqlite3_stmt *) * ZBDatabaseStatementTypeCount);
-        if (!preparedStatements) {
-            ZBLog(@"[Zebra] Failed to allocate buffer for prepared statements");
-            result = SQLITE_NOMEM;
+    preparedStatements = (sqlite3_stmt **) malloc(sizeof(sqlite3_stmt *) * ZBDatabaseStatementTypeCount);
+    if (!preparedStatements) {
+        ZBLog(@"[Zebra] Failed to allocate buffer for prepared statements");
+        return SQLITE_NOMEM;
+    } else {
+        for (int i = 0; i < ZBDatabaseStatementTypeCount; i++) {
+            preparedStatements[i] = NULL;
         }
-
-        if (result == SQLITE_OK) {
-            for (unsigned int i = 0; i < ZBDatabaseStatementTypeCount; i++) {
-                ZBDatabaseStatementType statementType = (ZBDatabaseStatementType)i;
-                const char *statement = [[self statementStringForStatementType:statementType] UTF8String];
-                result = sqlite3_prepare(database, statement, -1, &preparedStatements[statementType], NULL);
-                if (result != SQLITE_OK) {
-                    ZBLog(@"[Zebra] Failed to prepare sqlite statement %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
-                    free(preparedStatements);
-                    preparedStatements = NULL;
-                    break;
-                }
-            }
-        }
-    });
-    return result;
+    }
+    
+    return SQLITE_OK;
 }
 
 #pragma mark - Managing Transactions
 
 - (int)beginTransaction {
-    __block int result;
-    dispatch_sync(databaseQueue, ^{
-        result = sqlite3_exec(database, "BEGIN EXCLUSIVE TRANSACTION;", NULL, NULL, NULL);
-        if (result != SQLITE_OK) {
-            ZBLog(@"[Zebra] Failed to begin transaction with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
-        }
-    });
+    int result = sqlite3_exec(database, "BEGIN EXCLUSIVE TRANSACTION;", NULL, NULL, NULL);
+    if (result != SQLITE_OK) {
+        ZBLog(@"[Zebra] Failed to begin transaction with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+    }
     return result;
 }
 
 - (int)endTransaction {
-    __block int result;
-    dispatch_sync(databaseQueue, ^{
-        result = sqlite3_exec(database, "COMMIT;", NULL, NULL, NULL);
-        if (result != SQLITE_OK) {
-            ZBLog(@"[Zebra] Failed to commit transaction with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
-        }
-    });
+    int result = sqlite3_exec(database, "COMMIT;", NULL, NULL, NULL);
+    if (result != SQLITE_OK) {
+        ZBLog(@"[Zebra] Failed to commit transaction with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+    }
     return result;
 }
 
 - (void)performTransaction:(void (^)(void))transaction {
-    ZBLog(@"[Zebra] Performing transaction");
-    dispatch_sync(databaseQueue, ^{
+    @synchronized (self) {
         if ([self beginTransaction] != SQLITE_OK) return;
         transaction();
         [self endTransaction];
-    });
+    }
 }
 
 #pragma mark - Package Retrieval
 
 - (NSArray <ZBBasePackage *> *)packagesFromSource:(ZBSource *)source inSection:(NSString *)section {
-    __block NSMutableArray *packages = [NSMutableArray new];
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement;
-        int result = SQLITE_OK;
-        if (section) {
-            statement = [self preparedStatementOfType:ZBDatabaseStatementTypePackagesFromSourceAndSection];
-            result &= sqlite3_bind_text(statement, 1, source.uuid.UTF8String, -1, SQLITE_TRANSIENT);
-            result &= sqlite3_bind_text(statement, 2, section.UTF8String, -1, SQLITE_TRANSIENT);
-        } else {
-            statement = [self preparedStatementOfType:ZBDatabaseStatementTypePackagesFromSource];
-            result = sqlite3_bind_text(statement, 1, source.uuid.UTF8String, -1, SQLITE_TRANSIENT);
-        }
-        
-        if (result == SQLITE_OK) {
-            result = [self beginTransaction];
-        }
-        
-        if (result == SQLITE_OK) {
-            do {
-                result = sqlite3_step(statement);
-                if (result == SQLITE_ROW) {
-                    ZBBasePackage *package = [[ZBBasePackage alloc] initFromSQLiteStatement:statement];
-                    if (package) [packages addObject:package];
-                }
-            } while (result == SQLITE_ROW);
-            
-            if (result != SQLITE_DONE) {
-                ZBLog(@"[Zebra] Failed to query packages from %@ with error %d (%s, %d)", source.uuid, result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+    NSMutableArray *packages = [NSMutableArray new];
+    sqlite3_stmt *statement;
+    __block int result = SQLITE_OK;
+    if (section) {
+        statement = [self preparedStatementOfType:ZBDatabaseStatementTypePackagesFromSourceAndSection];
+        result &= sqlite3_bind_text(statement, 1, source.uuid.UTF8String, -1, SQLITE_TRANSIENT);
+        result &= sqlite3_bind_text(statement, 2, section.UTF8String, -1, SQLITE_TRANSIENT);
+    } else {
+        statement = [self preparedStatementOfType:ZBDatabaseStatementTypePackagesFromSource];
+        result = sqlite3_bind_text(statement, 1, source.uuid.UTF8String, -1, SQLITE_TRANSIENT);
+    }
+    
+    if (result != SQLITE_OK) return NULL;
+    
+    [self performTransaction:^{
+        do {
+            result = sqlite3_step(statement);
+            if (result == SQLITE_ROW) {
+                ZBBasePackage *package = [[ZBBasePackage alloc] initFromSQLiteStatement:statement];
+                if (package) [packages addObject:package];
             }
+        } while (result == SQLITE_ROW);
+            
+        if (result != SQLITE_DONE) {
+            ZBLog(@"[Zebra] Failed to query packages from %@ with error %d (%s, %d)", source.uuid, result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
         }
-        
-        [self endTransaction];
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-    });
+    }];
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+    
     return packages;
 }
 
 - (ZBPackage *)packageWithUniqueIdentifier:(NSString *)uuid {
-    __block ZBPackage *package;
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypePackagesWithUUID];
-        int result = sqlite3_bind_text(statement, 1, uuid.UTF8String, -1, SQLITE_TRANSIENT);
-        
-        if (result == SQLITE_OK) {
-            result = sqlite3_step(statement);
-            if (result == SQLITE_ROW) {
-                package = [[ZBPackage alloc] initFromSQLiteStatement:statement];
-            }
-            
-            if (result != SQLITE_OK && result != SQLITE_ROW) {
-                ZBLog(@"[Zebra] Failed to query package with uuid with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
-            }
+    
+    sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypePackagesWithUUID];
+    int result = sqlite3_bind_text(statement, 1, uuid.UTF8String, -1, SQLITE_TRANSIENT);
+    
+    if (result != SQLITE_OK) return NULL;
+    
+    ZBPackage *package = NULL;
+    @synchronized (self) {
+        result = sqlite3_step(statement);
+        if (result == SQLITE_ROW) {
+            package = [[ZBPackage alloc] initFromSQLiteStatement:statement];
         }
         
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-    });
+        if (result != SQLITE_OK && result != SQLITE_ROW) {
+            ZBLog(@"[Zebra] Failed to query package with uuid with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+        }
+    }
+    
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
     return package;
 }
 
 - (NSArray <ZBPackage *> *)updatesForPackageList:(NSDictionary <NSString *,NSString *> *)packageList {
-    __block NSArray *updates = NULL;
-    dispatch_sync(databaseQueue, ^{
-        NSMutableArray *tempPackages = [NSMutableArray new];
-        int result = [self beginTransaction];
-        if (result == SQLITE_OK) {
-            [packageList enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull identifier, NSString * _Nonnull version, BOOL * _Nonnull stop) {
-                if (![identifier containsString:@"gsc."] && ![identifier containsString:@"cy+"] && ![ZBSettings areUpdatesIgnoredForPackageIdentifier:identifier]) {
-                    NSString *highestVersion = [self highestVersionOfPackageIdentifier:identifier];
-                    if (![highestVersion isEqual:version]) {
-                        ZBBasePackage *basePackage = [self basePackageWithIdentifier:identifier version:highestVersion];
-                        if (basePackage) [tempPackages addObject:basePackage];
-                    }
+    NSMutableArray *updates = [NSMutableArray new];
+    
+    @synchronized (self) {
+        [packageList enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull identifier, NSString * _Nonnull version, BOOL * _Nonnull stop) {
+            if (![identifier containsString:@"gsc."] && ![identifier containsString:@"cy+"] && ![ZBSettings areUpdatesIgnoredForPackageIdentifier:identifier]) {
+                NSString *highestVersion = [self highestVersionOfPackageIdentifier:identifier];
+                if (![highestVersion isEqual:version]) {
+                    ZBBasePackage *basePackage = [self basePackageWithIdentifier:identifier version:highestVersion];
+                    if (basePackage) [updates addObject:basePackage];
                 }
-            }];
-        }
-        result = [self endTransaction];
-        updates = tempPackages;
-    });
+            }
+        }];
+    }
+    
     return [updates sortedArrayUsingDescriptors:@[[[NSSortDescriptor alloc] initWithKey:@"name" ascending:YES selector:@selector(caseInsensitiveCompare:)]]];
 }
 
 - (ZBBasePackage *)basePackageWithIdentifier:(NSString *)identifier version:(NSString *)version {
-    __block ZBBasePackage *package = NULL;
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeBasePackageWithVersion];
-        int result = sqlite3_bind_text(statement, 1, identifier.UTF8String, -1, SQLITE_TRANSIENT);
-        if (result == SQLITE_OK) {
-            result = sqlite3_bind_text(statement, 2, version.UTF8String, -1, SQLITE_TRANSIENT);
-        }
-        
-        if (result == SQLITE_OK) {
-            result = sqlite3_step(statement);
-            if (result == SQLITE_ROW) {
-                ZBBasePackage *basePackage = [[ZBBasePackage alloc] initFromSQLiteStatement:statement];
-                if (basePackage) package = basePackage;
-            }
+    sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeBasePackageWithVersion];
+    int result = sqlite3_bind_text(statement, 1, identifier.UTF8String, -1, SQLITE_TRANSIENT);
+    if (result == SQLITE_OK) {
+        result = sqlite3_bind_text(statement, 2, version.UTF8String, -1, SQLITE_TRANSIENT);
+    }
+    
+    if (result != SQLITE_OK) return NULL;
+    
+    ZBBasePackage *package = NULL;
+    @synchronized (self) {
+        result = sqlite3_step(statement);
+        if (result == SQLITE_ROW) {
+            ZBBasePackage *basePackage = [[ZBBasePackage alloc] initFromSQLiteStatement:statement];
+            if (basePackage) package = basePackage;
         }
         
         if (result != SQLITE_DONE && result != SQLITE_OK && result != SQLITE_ROW) {
             ZBLog(@"[Zebra] Failed to get version of package with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
         }
-        
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-    });
+    }
+    
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
     return package;
 }
 
 - (NSString *)highestVersionOfPackageIdentifier:(NSString *)packageIdentifier {
-    __block NSString *highestVersion = NULL;
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeHighestVersionOfPackage];
-        int result = sqlite3_bind_text(statement, 1, packageIdentifier.UTF8String, -1, SQLITE_TRANSIENT);
-        
-        if (result == SQLITE_OK) {
-            result = sqlite3_step(statement);
-            if (result == SQLITE_ROW) {
-                const char *version = (const char *)sqlite3_column_text(statement, 0);
-                if ((version && version[0] != '\0')) highestVersion = [NSString stringWithUTF8String:version];
-            }
+    sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeHighestVersionOfPackage];
+    int result = sqlite3_bind_text(statement, 1, packageIdentifier.UTF8String, -1, SQLITE_TRANSIENT);
+    
+    if (result != SQLITE_OK) return NULL;
+    
+    NSString *highestVersion = NULL;
+    @synchronized (self) {
+        result = sqlite3_step(statement);
+        if (result == SQLITE_ROW) {
+            const char *version = (const char *)sqlite3_column_text(statement, 0);
+            if ((version && version[0] != '\0')) highestVersion = [NSString stringWithUTF8String:version];
         }
         
         if (result != SQLITE_DONE && result != SQLITE_OK && result != SQLITE_ROW) {
             ZBLog(@"[Zebra] Failed to get highest version of package with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
         }
-        
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-    });
+    }
+    
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
     return highestVersion;
 }
 
 - (ZBPackage *)installedInstanceOfPackage:(ZBPackage *)package {
     if ([package.source.uuid isEqualToString:@"_var_lib_dpkg_status"]) return package;
     
-    __block ZBPackage *installedInstance = NULL;
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeInstalledInstanceOfPackage];
-        int result = sqlite3_bind_text(statement, 1, package.identifier.UTF8String, -1, SQLITE_TRANSIENT);
+    sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeInstalledInstanceOfPackage];
+    int result = sqlite3_bind_text(statement, 1, package.identifier.UTF8String, -1, SQLITE_TRANSIENT);
         
-        if (result == SQLITE_OK) {
-            result = sqlite3_step(statement);
-            if (result == SQLITE_ROW) {
-                installedInstance = [[ZBPackage alloc] initFromSQLiteStatement:statement];
-            }
-            
-            if (result != SQLITE_DONE && result != SQLITE_OK && result != SQLITE_ROW) {
-                ZBLog(@"[Zebra] Failed to get installed instance of package with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
-            }
+    if (result != SQLITE_OK) return NULL;
+    
+    ZBPackage *installedInstance = NULL;
+    @synchronized (self) {
+        result = sqlite3_step(statement);
+        if (result == SQLITE_ROW) {
+            installedInstance = [[ZBPackage alloc] initFromSQLiteStatement:statement];
         }
-        
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-    });
+            
+        if (result != SQLITE_DONE && result != SQLITE_OK && result != SQLITE_ROW) {
+            ZBLog(@"[Zebra] Failed to get installed instance of package with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+        }
+    }
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
     return installedInstance;
 }
 
 - (NSArray <ZBPackage *> *)packagesByAuthorWithName:(NSString *)name email:(NSString *_Nullable)email {
-    __block NSArray *ret = NULL;
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement;
-        const char *query;
-        if (email) {
-            query = "SELECT " BASE_PACKAGE_COLUMNS " FROM (SELECT identifier, maxversion(version) AS max_version FROM " PACKAGES_TABLE_NAME " WHERE authorName = ? AND authorEmail = ? GROUP BY identifier) as v INNER JOIN " PACKAGES_TABLE_NAME " AS p ON p.identifier = v.identifier AND p.version = v.max_version;";
-        } else {
-            query = "SELECT " BASE_PACKAGE_COLUMNS " FROM (SELECT identifier, maxversion(version) AS max_version FROM " PACKAGES_TABLE_NAME " WHERE authorName = ? GROUP BY identifier) as v INNER JOIN " PACKAGES_TABLE_NAME " AS p ON p.identifier = v.identifier AND p.version = v.max_version;";
-        }
+    sqlite3_stmt *statement;
+    const char *query;
+    if (email) {
+        query = "SELECT " BASE_PACKAGE_COLUMNS " FROM (SELECT identifier, maxversion(version) AS max_version FROM " PACKAGES_TABLE_NAME " WHERE authorName = ? AND authorEmail = ? GROUP BY identifier) as v INNER JOIN " PACKAGES_TABLE_NAME " AS p ON p.identifier = v.identifier AND p.version = v.max_version;";
+    } else {
+        query = "SELECT " BASE_PACKAGE_COLUMNS " FROM (SELECT identifier, maxversion(version) AS max_version FROM " PACKAGES_TABLE_NAME " WHERE authorName = ? GROUP BY identifier) as v INNER JOIN " PACKAGES_TABLE_NAME " AS p ON p.identifier = v.identifier AND p.version = v.max_version;";
+    }
         
-        int result = sqlite3_prepare_v2(database, query, -1, &statement, nil); // Since this is one of the lesser used queries, no reason to waste time pre-preparing it
-        if (result == SQLITE_OK) {
-            result = [self beginTransaction];
-            result = sqlite3_bind_text(statement, 1, name.UTF8String, -1, SQLITE_TRANSIENT);
-            if (email) result = sqlite3_bind_text(statement, 2, email.UTF8String, -1, SQLITE_TRANSIENT);
-        }
-        
-        NSMutableArray *results = [NSMutableArray new];
-        if (result == SQLITE_OK) {
-            do {
-                result = sqlite3_step(statement);
-                if (result == SQLITE_ROW) {
-                    ZBBasePackage *package = [[ZBBasePackage alloc] initFromSQLiteStatement:statement];
-                    
-                    if (package) [results addObject:package];
-                }
-            } while (result == SQLITE_ROW);
-            
-            if (result != SQLITE_DONE) {
-                ZBLog(@"[Zebra] Failed to query packages by author with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+    __block int result = sqlite3_prepare_v2(database, query, -1, &statement, nil); // Since this is one of the lesser used queries, no reason to waste time pre-preparing it
+    if (result == SQLITE_OK) {
+        result = [self beginTransaction];
+        result = sqlite3_bind_text(statement, 1, name.UTF8String, -1, SQLITE_TRANSIENT);
+        if (email) result = sqlite3_bind_text(statement, 2, email.UTF8String, -1, SQLITE_TRANSIENT);
+    }
+    
+    if (result != SQLITE_OK) return NULL;
+    
+    NSMutableArray *results = [NSMutableArray new];
+    [self performTransaction:^{
+        do {
+            result = sqlite3_step(statement);
+            if (result == SQLITE_ROW) {
+                ZBBasePackage *package = [[ZBBasePackage alloc] initFromSQLiteStatement:statement];
+                
+                if (package) [results addObject:package];
             }
+        } while (result == SQLITE_ROW);
+        
+        if (result != SQLITE_DONE) {
+            ZBLog(@"[Zebra] Failed to query packages by author with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
         }
-        [self endTransaction];
-        
-        sqlite3_finalize(statement);
-        
-        ret = results;
-    });
-    return ret;
+    }];
+    sqlite3_finalize(statement);
+    return results;
 }
 
 - (NSArray <ZBPackage *> *)latestPackages:(NSUInteger)limit {
-    __block NSArray *ret = NULL;
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement;
-        int result = SQLITE_OK;
-        if (limit == -1) {
-            statement = [self preparedStatementOfType:ZBDatabaseStatementTypeLatestPackages];
-        } else {
-            statement = [self preparedStatementOfType:ZBDatabaseStatementTypeLatestPackagesWithLimit];
-            result = sqlite3_bind_int(statement, 1, (int)limit);
-        }
+    sqlite3_stmt *statement;
+    __block int result = SQLITE_OK;
+    if (limit == -1) {
+        statement = [self preparedStatementOfType:ZBDatabaseStatementTypeLatestPackages];
+    } else {
+        statement = [self preparedStatementOfType:ZBDatabaseStatementTypeLatestPackagesWithLimit];
+        result = sqlite3_bind_int(statement, 1, (int)limit);
+    }
         
-        if (result == SQLITE_OK) {
-            result = [self beginTransaction];
-        }
-        
-        NSMutableArray *results = [NSMutableArray new];
-        if (result == SQLITE_OK) {
-            do {
-                result = sqlite3_step(statement);
-                if (result == SQLITE_ROW) {
-                    ZBBasePackage *package = [[ZBBasePackage alloc] initFromSQLiteStatement:statement];
-                    
-                    if (package) [results addObject:package];
-                }
-            } while (result == SQLITE_ROW);
-            
-            if (result != SQLITE_DONE) {
-                ZBLog(@"[Zebra] Failed to query latest packages with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+    if (result != SQLITE_OK) return NULL;
+    
+    NSMutableArray *results = [NSMutableArray new];
+    [self performTransaction:^{
+        do {
+            result = sqlite3_step(statement);
+            if (result == SQLITE_ROW) {
+                ZBBasePackage *package = [[ZBBasePackage alloc] initFromSQLiteStatement:statement];
+                
+                if (package) [results addObject:package];
             }
+        } while (result == SQLITE_ROW);
+        
+        if (result != SQLITE_DONE) {
+            ZBLog(@"[Zebra] Failed to query latest packages with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
         }
-        [self endTransaction];
-        
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-        
-        ret = results;
-    });
-    return ret;
+    }];
+    
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+    return results;
 }
 
 - (NSArray <ZBPackage *> *)packagesFromIdentifiers:(NSArray <NSString *> *)requestedPackages {
-    __block NSArray *packages = NULL;
-    dispatch_sync(databaseQueue, ^{
-        const char *query = "SELECT " BASE_PACKAGE_COLUMNS " FROM (SELECT identifier, maxversion(version) AS max_version FROM " PACKAGES_TABLE_NAME " WHERE identifier IN (?) GROUP BY identifier) as v INNER JOIN " PACKAGES_TABLE_NAME " AS p ON p.identifier = v.identifier AND p.version = v.max_version;";
-        NSString *identifierString = [requestedPackages componentsJoinedByString:@"\', \'"];
-        sqlite3_stmt *statement;
-        int result = sqlite3_prepare_v2(database, query, -1, &statement, nil);
-        if (result == SQLITE_OK) {
-            result = sqlite3_bind_text(statement, 1, identifierString.UTF8String, -1, SQLITE_TRANSIENT);
-        }
+    const char *query = "SELECT " BASE_PACKAGE_COLUMNS " FROM (SELECT identifier, maxversion(version) AS max_version FROM " PACKAGES_TABLE_NAME " WHERE identifier IN (?) GROUP BY identifier) as v INNER JOIN " PACKAGES_TABLE_NAME " AS p ON p.identifier = v.identifier AND p.version = v.max_version;";
+    NSString *identifierString = [requestedPackages componentsJoinedByString:@"\', \'"];
+    sqlite3_stmt *statement;
+    __block int result = sqlite3_prepare_v2(database, query, -1, &statement, nil);
+    if (result == SQLITE_OK) {
+        result = sqlite3_bind_text(statement, 1, identifierString.UTF8String, -1, SQLITE_TRANSIENT);
+    }
         
-        if (result == SQLITE_OK) {
-            result = [self beginTransaction];
-        }
-        
-        NSMutableArray *results = [NSMutableArray new];
-        if (result == SQLITE_OK) {
-            do {
-                result = sqlite3_step(statement);
-                if (result == SQLITE_ROW) {
-                    ZBBasePackage *package = [[ZBBasePackage alloc] initFromSQLiteStatement:statement];
-                    
-                    if (package) [results addObject:package];
-                }
-            } while (result == SQLITE_ROW);
-            
-            if (result != SQLITE_DONE) {
-                ZBLog(@"[Zebra] Failed to query packages from identifiers with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+    if (result != SQLITE_OK) return NULL;
+    
+    NSMutableArray *results = [NSMutableArray new];
+    [self performTransaction:^{
+        do {
+            result = sqlite3_step(statement);
+            if (result == SQLITE_ROW) {
+                ZBBasePackage *package = [[ZBBasePackage alloc] initFromSQLiteStatement:statement];
+                
+                if (package) [results addObject:package];
             }
+        } while (result == SQLITE_ROW);
+        
+        if (result != SQLITE_DONE) {
+            ZBLog(@"[Zebra] Failed to query packages from identifiers with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
         }
-        [self endTransaction];
-        
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-        
-        packages = results;
-    });
-    return packages;
+    }];
+    
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+    return results;
 }
 
 - (NSArray *)packagesWithReachableIcon:(int)limit excludeFrom:(NSArray <ZBSource *> *)blacklistedSources {
-    __block NSArray *result = NULL;
-    dispatch_sync(databaseQueue, ^{
-        NSMutableArray *packages = [NSMutableArray new];
-        NSMutableArray *sourceUUIDs = [NSMutableArray arrayWithObject:@"_var_lib_dpkg_status_"];
+    NSMutableArray *packages = [NSMutableArray new];
+    NSMutableArray *sourceUUIDs = [NSMutableArray arrayWithObject:@"_var_lib_dpkg_status_"];
         
-        for (ZBSource *source in blacklistedSources) {
-            [sourceUUIDs addObject:source.uuid];
-        }
-        NSString *excludeString = [NSString stringWithFormat:@"(%@)", [sourceUUIDs componentsJoinedByString:@", "]];
-        NSString *query = [NSString stringWithFormat:@"SELECT * FROM PACKAGES WHERE SOURCE NOT IN %@ AND ICON IS NOT NULL ORDER BY RANDOM() LIMIT %d;", excludeString, limit];
-        
-        sqlite3_stmt *statement = NULL;
-        if (sqlite3_prepare_v2(database, [query UTF8String], -1, &statement, nil) == SQLITE_OK) {
+    for (ZBSource *source in blacklistedSources) {
+        [sourceUUIDs addObject:source.uuid];
+    }
+    NSString *excludeString = [NSString stringWithFormat:@"(%@)", [sourceUUIDs componentsJoinedByString:@", "]];
+    NSString *query = [NSString stringWithFormat:@"SELECT * FROM PACKAGES WHERE SOURCE NOT IN %@ AND ICON IS NOT NULL ORDER BY RANDOM() LIMIT %d;", excludeString, limit];
+    
+    sqlite3_stmt *statement = NULL;
+    if (sqlite3_prepare_v2(database, [query UTF8String], -1, &statement, nil) == SQLITE_OK) {
+        @synchronized (self) {
             while (sqlite3_step(statement) == SQLITE_ROW) {
                 ZBPackage *package = [[ZBPackage alloc] initFromSQLiteStatement:statement];
-                [packages addObject:package];
+                if (package) [packages addObject:package];
             }
         }
-        
-        result = packages;
-    });
-    return result;
+    }
+    
+    sqlite3_finalize(statement);
+    return packages;
 }
 
 - (NSArray <NSString *> *)allVersionsOfPackage:(ZBPackage *)package {
-    __block NSArray *versions = NULL;
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeAllVersionsOfPackages];
-        int result = sqlite3_bind_text(statement, 1, package.identifier.UTF8String, -1, SQLITE_TRANSIENT);
-        result &= [self beginTransaction];
-        
-        NSMutableArray *tempVersions = [NSMutableArray new];
-        if (result == SQLITE_OK) {
-            do {
-                result = sqlite3_step(statement);
-                if (result == SQLITE_ROW) {
-                    const char *version = (const char *)sqlite3_column_text(statement, 0);
-                    if (version) [tempVersions addObject:[NSString stringWithUTF8String:version]];
-                }
-            } while (result == SQLITE_ROW);
-        }
+    sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeAllVersionsOfPackages];
+    __block int result = sqlite3_bind_text(statement, 1, package.identifier.UTF8String, -1, SQLITE_TRANSIENT);
+    
+    if (result != SQLITE_OK) return NULL;
+    
+    NSMutableArray *versions = [NSMutableArray new];
+    [self performTransaction:^{
+        do {
+            result = sqlite3_step(statement);
+            if (result == SQLITE_ROW) {
+                const char *version = (const char *)sqlite3_column_text(statement, 0);
+                if (version) [versions addObject:[NSString stringWithUTF8String:version]];
+            }
+        } while (result == SQLITE_ROW);
         
         if (result != SQLITE_DONE && result != SQLITE_OK) {
             ZBLog(@"[Zebra] Failed to get all versions of package with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
         }
+    }];
         
-        result = [self endTransaction];
-        versions = tempVersions;
-        
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-    });
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
     return versions;
 }
 
 - (NSArray <ZBPackage *> *)allInstancesOfPackage:(ZBPackage *)package {
-    __block NSArray *packages = NULL;
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeAllInstancesOfPackage];
-        int result = sqlite3_bind_text(statement, 1, package.identifier.UTF8String, -1, SQLITE_TRANSIENT);
-        result &= [self beginTransaction];
-        
-        NSMutableArray *tempPackages = [NSMutableArray new];
-        if (result == SQLITE_OK) {
-            do {
-                result = sqlite3_step(statement);
-                if (result == SQLITE_ROW) {
-                    ZBBasePackage *package = [[ZBBasePackage alloc] initFromSQLiteStatement:statement];
-                    if (package) [tempPackages addObject:package];
-                }
-            } while (result == SQLITE_ROW);
-        }
+    sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeAllInstancesOfPackage];
+    __block int result = sqlite3_bind_text(statement, 1, package.identifier.UTF8String, -1, SQLITE_TRANSIENT);
+    
+    if (result != SQLITE_OK) return NULL;
+    
+    NSMutableArray *packages = [NSMutableArray new];
+    [self performTransaction:^{
+        do {
+            result = sqlite3_step(statement);
+            if (result == SQLITE_ROW) {
+                ZBBasePackage *package = [[ZBBasePackage alloc] initFromSQLiteStatement:statement];
+                if (package) [packages addObject:package];
+            }
+        } while (result == SQLITE_ROW);
         
         if (result != SQLITE_DONE && result != SQLITE_OK) {
             ZBLog(@"[Zebra] Failed to get all instances of package with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
         }
+    }];
         
-        result = [self endTransaction];
-        packages = tempPackages;
-        
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-    });
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
     return packages;
 }
 
 #pragma mark - Package Information
 
 - (NSString *)installedVersionOfPackage:(ZBPackage *)package {
-    __block NSString *installedVersion = NULL;
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeInstalledVersionOfPackage];
-        int result = sqlite3_bind_text(statement, 1, package.identifier.UTF8String, -1, SQLITE_TRANSIENT);
+    sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeInstalledVersionOfPackage];
+    int result = sqlite3_bind_text(statement, 1, package.identifier.UTF8String, -1, SQLITE_TRANSIENT);
         
-        if (result == SQLITE_OK) {
-            result = sqlite3_step(statement);
-            if (result == SQLITE_ROW) {
-                const char *version = (const char *)sqlite3_column_text(statement, 0);
-                if (version) {
-                    installedVersion = [NSString stringWithUTF8String:version];
-                }
-            }
-            
-            if (result != SQLITE_DONE && result != SQLITE_OK && result != SQLITE_ROW) {
-                ZBLog(@"[Zebra] Failed to get installed version of package with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+    if (result != SQLITE_OK) return NULL;
+        
+    NSString *installedVersion = NULL;
+    @synchronized (self) {
+        result = sqlite3_step(statement);
+        if (result == SQLITE_ROW) {
+            const char *version = (const char *)sqlite3_column_text(statement, 0);
+            if (version) {
+                installedVersion = [NSString stringWithUTF8String:version];
             }
         }
+    }
+            
+    if (result != SQLITE_DONE && result != SQLITE_OK && result != SQLITE_ROW) {
+        ZBLog(@"[Zebra] Failed to get installed version of package with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+    }
         
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-    });
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
     return installedVersion;
 }
 
 - (ZBPackage *)remoteInstanceOfPackage:(ZBPackage *)package withVersion:(NSString *)version {
-    __block ZBPackage *packageWithVersion = NULL;
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeRemoteInstanceOfPackageWithVersion];
-        int result = sqlite3_bind_text(statement, 1, package.identifier.UTF8String, -1, SQLITE_TRANSIENT);
-        result &= sqlite3_bind_text(statement, 2, version.UTF8String, -1, SQLITE_TRANSIENT);
+    sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeRemoteInstanceOfPackageWithVersion];
+    int result = sqlite3_bind_text(statement, 1, package.identifier.UTF8String, -1, SQLITE_TRANSIENT);
+    result &= sqlite3_bind_text(statement, 2, version.UTF8String, -1, SQLITE_TRANSIENT);
         
-        if (result == SQLITE_OK) {
-            result = sqlite3_step(statement);
-            if (result == SQLITE_ROW) {
-                ZBPackage *package = [[ZBPackage alloc] initFromSQLiteStatement:statement];
-                if (package) packageWithVersion = package;
-            }
+    if (result != SQLITE_OK) return NULL;
+    
+    ZBPackage *packageWithVersion = NULL;
+    @synchronized (self) {
+        result = sqlite3_step(statement);
+        if (result == SQLITE_ROW) {
+            ZBPackage *package = [[ZBPackage alloc] initFromSQLiteStatement:statement];
+            if (package) packageWithVersion = package;
         }
+    }
         
-        if (result != SQLITE_DONE && result != SQLITE_OK && result != SQLITE_ROW) {
-            ZBLog(@"[Zebra] Failed to get installed version of package with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
-        }
+    if (result != SQLITE_DONE && result != SQLITE_OK && result != SQLITE_ROW) {
+        ZBLog(@"[Zebra] Failed to get installed version of package with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+    }
         
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-    });
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
     return packageWithVersion;
 }
 
 - (BOOL)isPackageAvailable:(ZBPackage *)package checkVersion:(BOOL)checkVersion; {
     if (package.source.remote) return YES;
     
-    __block BOOL isAvailable = NO;
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeIsPackageAvailable + checkVersion];
-        int result = sqlite3_bind_text(statement, 1, package.identifier.UTF8String, -1, SQLITE_TRANSIENT);
-        if (checkVersion) result &= sqlite3_bind_text(statement, 2, package.version.UTF8String, -1, SQLITE_TRANSIENT);
+    sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeIsPackageAvailable + checkVersion];
+    int result = sqlite3_bind_text(statement, 1, package.identifier.UTF8String, -1, SQLITE_TRANSIENT);
+    if (checkVersion) result &= sqlite3_bind_text(statement, 2, package.version.UTF8String, -1, SQLITE_TRANSIENT);
         
-        if (result == SQLITE_OK) {
-            result = sqlite3_step(statement);
-            if (result == SQLITE_ROW) isAvailable = YES;
-        }
+    if (result != SQLITE_OK) return NO;
+    
+    BOOL isAvailable = NO;
+    @synchronized (self) {
+        result = sqlite3_step(statement);
+        if (result == SQLITE_ROW) isAvailable = YES;
+    }
         
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-    });
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
     return isAvailable;
 }
 
@@ -975,7 +901,7 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
     });
     
     currentSearchBlock = searchBlock;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), databaseQueue, searchBlock);
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), searchQueue, searchBlock);
 }
 
 - (void)searchForPackagesByDescription:(NSString *)description completion:(void (^)(NSArray <ZBPackage *> *packages))completion {
@@ -1015,7 +941,7 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
     });
     
     currentSearchBlock = searchBlock;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), databaseQueue, searchBlock);
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), searchQueue, searchBlock);
 }
 
 - (void)searchForPackagesByAuthorWithName:(NSString *)name completion:(void (^)(NSArray <ZBPackage *> *packages))completion {
@@ -1055,345 +981,317 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
     });
     
     currentSearchBlock = searchBlock;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), databaseQueue, searchBlock);
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), searchQueue, searchBlock);
 }
 
 #pragma mark - Source Retrieval
 
 - (NSSet <ZBSource *> *)sources {
-    __block NSSet *sources;
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeSources];
+    sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeSources];
+    
+    NSMutableSet *sources = [NSMutableSet new];
+    @synchronized (self) {
         int result = SQLITE_OK;
-        
-        NSMutableSet *tempSources = [NSMutableSet new];
         do {
             result = sqlite3_step(statement);
             if (result == SQLITE_ROW) {
                 ZBSource *source = [[ZBSource alloc] initWithSQLiteStatement:statement];
-                if (source) [tempSources addObject:source];
+                if (source) [sources addObject:source];
             }
         } while (result == SQLITE_ROW);
         
         if (result != SQLITE_DONE) {
             ZBLog(@"[Zebra] Failed to query sources with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
         }
-        
-        sqlite3_reset(statement);
-        
-        sources = tempSources;
-    });
+    }
+    
+    sqlite3_reset(statement);
     return sources;
 }
 
 - (ZBSource *)sourceWithUUID:(NSString *)uuid {
-    __block ZBSource *source = NULL;
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeSourceWithUUID];
-        int result = sqlite3_bind_text(statement, 1, uuid.UTF8String, -1, SQLITE_TRANSIENT);
-        
-        if (result == SQLITE_OK) {
-            result = sqlite3_step(statement);
-            if (result == SQLITE_ROW) {
-                source = [[ZBSource alloc] initWithSQLiteStatement:statement];
-            }
+    sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeSourceWithUUID];
+    int result = sqlite3_bind_text(statement, 1, uuid.UTF8String, -1, SQLITE_TRANSIENT);
+    
+    if (result != SQLITE_OK) return NULL;
+    
+    ZBSource *source = NULL;
+    @synchronized (self) {
+        result = sqlite3_step(statement);
+        if (result == SQLITE_ROW) {
+            source = [[ZBSource alloc] initWithSQLiteStatement:statement];
         }
-        
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-    });
+    }
+    
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
     return source;
 }
 
 #pragma mark - Source Information
 
 - (NSDictionary *)packageListFromSource:(ZBSource *)source {
-    __block NSDictionary *ret = NULL;
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypePackageListFromSource];
-        int result = sqlite3_bind_text(statement, 1, source.uuid.UTF8String, -1, SQLITE_TRANSIENT);
-        if (result == SQLITE_OK) {
-            result = [self beginTransaction];
-        }
-        
-        NSMutableDictionary *packageList = [NSMutableDictionary new];
-        if (result == SQLITE_OK) {
-            do {
-                result = sqlite3_step(statement);
-                if (result == SQLITE_ROW) {
-                    const char *identifierChars = (const char *)sqlite3_column_text(statement, 0);
-                    const char *versionChars = (const char *)sqlite3_column_text(statement, 1);
-                    if ((identifierChars && identifierChars[0] != '\0') && (versionChars && versionChars[0] != '\0')) {
-                        NSString *identifier = [NSString stringWithUTF8String:identifierChars];
-                        NSString *version = [NSString stringWithUTF8String:versionChars];
-                        if (identifier && version) packageList[identifier] = version;
-                    }
+    sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypePackageListFromSource];
+    __block int result = sqlite3_bind_text(statement, 1, source.uuid.UTF8String, -1, SQLITE_TRANSIENT);
+    
+    if (result != SQLITE_OK) return NULL;
+    
+    NSMutableDictionary *packageList = [NSMutableDictionary new];
+    [self performTransaction:^{
+        do {
+            result = sqlite3_step(statement);
+            if (result == SQLITE_ROW) {
+                const char *identifierChars = (const char *)sqlite3_column_text(statement, 0);
+                const char *versionChars = (const char *)sqlite3_column_text(statement, 1);
+                if ((identifierChars && identifierChars[0] != '\0') && (versionChars && versionChars[0] != '\0')) {
+                    NSString *identifier = [NSString stringWithUTF8String:identifierChars];
+                    NSString *version = [NSString stringWithUTF8String:versionChars];
+                    if (identifier && version) packageList[identifier] = version;
                 }
-            } while (result == SQLITE_ROW);
-        }
-        [self endTransaction];
-        
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-        
-        ret = packageList;
-    });
-    return ret;
+            }
+        } while (result == SQLITE_ROW);
+    }];
+    
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+    return packageList;
 }
 
 - (NSDictionary *)virtualPackageListFromSource:(ZBSource *)source {
-    __block NSDictionary *ret = NULL;
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeVirtualPackageListFromSource];
-        int result = sqlite3_bind_text(statement, 1, source.uuid.UTF8String, -1, SQLITE_TRANSIENT);
-        if (result == SQLITE_OK) {
-            result = [self beginTransaction];
-        }
-        
-        NSMutableDictionary *packageList = [NSMutableDictionary new];
-        if (result == SQLITE_OK) {
-            do {
-                result = sqlite3_step(statement);
-                if (result == SQLITE_ROW) {
-                    const char *provides = (const char *)sqlite3_column_text(statement, 0);
-                    if (provides) {
-                        NSArray *allProvides = [[NSString stringWithUTF8String:provides] componentsSeparatedByString:@","];
-                        for (NSString *virtualPackage in allProvides) {
-                            NSArray *components = [ZBDependencyResolver separateVersionComparison:virtualPackage];
-                            packageList[components[0]] = components[2];
-                        }
+    sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeVirtualPackageListFromSource];
+    __block int result = sqlite3_bind_text(statement, 1, source.uuid.UTF8String, -1, SQLITE_TRANSIENT);
+    
+    if (result != SQLITE_OK) return NULL;
+    
+    NSMutableDictionary *packageList = [NSMutableDictionary new];
+    [self performTransaction:^{
+        do {
+            result = sqlite3_step(statement);
+            if (result == SQLITE_ROW) {
+                const char *provides = (const char *)sqlite3_column_text(statement, 0);
+                if (provides) {
+                    NSArray *allProvides = [[NSString stringWithUTF8String:provides] componentsSeparatedByString:@","];
+                    for (NSString *virtualPackage in allProvides) {
+                        NSArray *components = [ZBDependencyResolver separateVersionComparison:virtualPackage];
+                        packageList[components[0]] = components[2];
                     }
                 }
-            } while (result == SQLITE_ROW);
-        }
-        [self endTransaction];
-        
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-        
-        ret = packageList;
-    });
-    return ret;
+            }
+        } while (result == SQLITE_ROW);
+    }];
+    
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+    return packageList;
 }
 
 
 - (NSSet *)uniqueIdentifiersForPackagesFromSource:(ZBBaseSource *)source {
-    __block NSMutableSet *uuids = [NSMutableSet new];
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeUUIDsFromSource];
-        int result = sqlite3_bind_text(statement, 1, [source.uuid UTF8String], -1, SQLITE_TRANSIENT);
-        if (result == SQLITE_OK) {
-            result = [self beginTransaction];
-        }
-        
-        if (result == SQLITE_OK) {
-            do {
-                result = sqlite3_step(statement);
-                if (result == SQLITE_ROW) {
-                    const char *uuid = (const char *)sqlite3_column_text(statement, 0);
-                    if (uuid) {
-                        [uuids addObject:[NSString stringWithUTF8String:uuid]];
-                    }
+    sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeUUIDsFromSource];
+    __block int result = sqlite3_bind_text(statement, 1, [source.uuid UTF8String], -1, SQLITE_TRANSIENT);
+    
+    if (result != SQLITE_OK) return NULL;
+    
+    NSMutableSet *uuids = [NSMutableSet new];
+    [self performTransaction:^{
+        do {
+            result = sqlite3_step(statement);
+            if (result == SQLITE_ROW) {
+                const char *uuid = (const char *)sqlite3_column_text(statement, 0);
+                if (uuid) {
+                    [uuids addObject:[NSString stringWithUTF8String:uuid]];
                 }
-            } while (result == SQLITE_ROW);
-            
-            if (result != SQLITE_DONE) {
-                ZBLog(@"[Zebra] Failed to query package uuids from %@ with error %d (%s, %d)", source.uuid, result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
             }
-        }
+        } while (result == SQLITE_ROW);
         
-        [self endTransaction];
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-    });
+        if (result != SQLITE_DONE) {
+            ZBLog(@"[Zebra] Failed to query package uuids from %@ with error %d (%s, %d)", source.uuid, result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
+        }
+    }];
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
     return uuids;
 }
 
 - (NSUInteger)numberOfPackagesInSource:(ZBSource *)source {
-    __block NSUInteger packageCount = 0;
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypePackagesInSourceCount];
-        
-        int result = sqlite3_bind_text(statement, 1, source.uuid.UTF8String, -1, SQLITE_TRANSIENT);
-        if (result == SQLITE_OK) {
-            result = sqlite3_step(statement);
-            if (result == SQLITE_ROW) {
-                packageCount = sqlite3_column_int(statement, 0);
-            }
+    sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypePackagesInSourceCount];
+    int result = sqlite3_bind_text(statement, 1, source.uuid.UTF8String, -1, SQLITE_TRANSIENT);
+    
+    if (result != SQLITE_OK) return -1;
+    
+    NSUInteger packageCount = 0;
+    @synchronized (self) {
+        result = sqlite3_step(statement);
+        if (result == SQLITE_ROW) {
+            packageCount = sqlite3_column_int(statement, 0);
         }
         
         if (result != SQLITE_OK && result != SQLITE_ROW) {
             ZBLog(@"[Zebra] Failed to obtain package count from source with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
         }
-        
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-    });
+    }
+    
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
     return packageCount;
 }
 
 - (NSDictionary *)sectionReadoutForSource:(ZBSource *)source {
-    __block NSDictionary *sections = NULL;
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeSectionReadout];
-        int result = [self beginTransaction];
+    sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeSectionReadout];
+    __block int result = sqlite3_bind_text(statement, 1, source.uuid.UTF8String, -1, SQLITE_TRANSIENT);
         
-        result = sqlite3_bind_text(statement, 1, source.uuid.UTF8String, -1, SQLITE_TRANSIENT);
-        
-        NSMutableDictionary *sectionReadout = [NSMutableDictionary new];
-        if (result == SQLITE_OK) {
-            do {
-                result = sqlite3_step(statement);
-                if (result == SQLITE_ROW) {
-                    const char *section = (const char *)sqlite3_column_text(statement, 0);
-                    if (section) {
-                        int packageCount = sqlite3_column_int(statement, 1);
-                        sectionReadout[[NSString stringWithUTF8String:section]] = @(packageCount);
-                    }
+    if (result != SQLITE_OK) return NULL;
+    
+    NSMutableDictionary *sectionReadout = [NSMutableDictionary new];
+    [self performTransaction:^{
+        do {
+            result = sqlite3_step(statement);
+            if (result == SQLITE_ROW) {
+                const char *section = (const char *)sqlite3_column_text(statement, 0);
+                if (section) {
+                    int packageCount = sqlite3_column_int(statement, 1);
+                    sectionReadout[[NSString stringWithUTF8String:section]] = @(packageCount);
                 }
-            } while (result == SQLITE_ROW);
-            
-            if (result != SQLITE_DONE) {
-                ZBLog(@"[Zebra] Failed to query section readout with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
             }
-            
-            sectionReadout[@"Uncategorized"] = sectionReadout[@""];
-            [sectionReadout removeObjectForKey:@""];
-            
-            sections = sectionReadout;
+        } while (result == SQLITE_ROW);
+        
+        if (result != SQLITE_DONE) {
+            ZBLog(@"[Zebra] Failed to query section readout with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
         }
-
-        [self endTransaction];
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-    });
-    return sections;
+    }];
+            
+    sectionReadout[@"Uncategorized"] = sectionReadout[@""];
+    [sectionReadout removeObjectForKey:@""];
+    
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+    return sectionReadout;
 }
 
 #pragma mark - Package Management
 
 - (void)insertPackage:(char **)package {
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeInsertPackage];
-
-        sqlite3_bind_text(statement, ZBPackageColumnIdentifier + 1, package[ZBPackageColumnIdentifier], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBPackageColumnName + 1, package[ZBPackageColumnName], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBPackageColumnVersion + 1, package[ZBPackageColumnVersion], -1, SQLITE_TRANSIENT);
+    sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeInsertPackage];
+    
+    sqlite3_bind_text(statement, ZBPackageColumnIdentifier + 1, package[ZBPackageColumnIdentifier], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBPackageColumnName + 1, package[ZBPackageColumnName], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBPackageColumnVersion + 1, package[ZBPackageColumnVersion], -1, SQLITE_TRANSIENT);
+    
+    char *author = package[ZBPackageColumnAuthorName];
+    char *emailBegin = strchr(author, '<');
+    char *emailEnd = strchr(author, '>');
+    if (emailBegin && emailEnd) {
+        char *email = (char *)malloc(emailEnd - emailBegin);
+        memcpy(email, emailBegin + 1, emailEnd - emailBegin - 1);
+        email[emailEnd - emailBegin - 1] = 0;
         
-        char *author = package[ZBPackageColumnAuthorName];
-        char *emailBegin = strchr(author, '<');
-        char *emailEnd = strchr(author, '>');
-        if (emailBegin && emailEnd) {
-            char *email = (char *)malloc(emailEnd - emailBegin);
-            memcpy(email, emailBegin + 1, emailEnd - emailBegin - 1);
-            email[emailEnd - emailBegin - 1] = 0;
-            
-            if (author < emailBegin && *(emailBegin - 1) == ' ') {
-                emailBegin--;
-            }
-            *emailBegin = 0;
-            
-            if (strcmp(author, "") == 0) { // If somehow the package maintainer messed up the email...
-                strcpy(author, email);
-            }
-            sqlite3_bind_text(statement, ZBPackageColumnAuthorName + 1, author, -1, SQLITE_TRANSIENT);
-            sqlite3_bind_text(statement, ZBPackageColumnAuthorEmail + 1, email, -1, SQLITE_TRANSIENT);
-            free(email);
-        } else {
-            sqlite3_bind_text(statement, ZBPackageColumnAuthorName + 1, author, -1, SQLITE_TRANSIENT);
-            sqlite3_bind_null(statement, ZBPackageColumnAuthorEmail + 1);
+        if (author < emailBegin && *(emailBegin - 1) == ' ') {
+            emailBegin--;
         }
+        *emailBegin = 0;
         
-        sqlite3_bind_text(statement, ZBPackageColumnConflicts + 1, package[ZBPackageColumnConflicts], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBPackageColumnDepends + 1, package[ZBPackageColumnDepends], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBPackageColumnDepictionURL + 1, package[ZBPackageColumnDepictionURL], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_int(statement, ZBPackageColumnDownloadSize + 1, atoi(package[ZBPackageColumnDownloadSize]));
+        if (strcmp(author, "") == 0) { // If somehow the package maintainer messed up the email...
+            strcpy(author, email);
+        }
+        sqlite3_bind_text(statement, ZBPackageColumnAuthorName + 1, author, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(statement, ZBPackageColumnAuthorEmail + 1, email, -1, SQLITE_TRANSIENT);
+        free(email);
+    } else {
+        sqlite3_bind_text(statement, ZBPackageColumnAuthorName + 1, author, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_null(statement, ZBPackageColumnAuthorEmail + 1);
+    }
+    
+    sqlite3_bind_text(statement, ZBPackageColumnConflicts + 1, package[ZBPackageColumnConflicts], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBPackageColumnDepends + 1, package[ZBPackageColumnDepends], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBPackageColumnDepictionURL + 1, package[ZBPackageColumnDepictionURL], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, ZBPackageColumnDownloadSize + 1, atoi(package[ZBPackageColumnDownloadSize]));
     //    package.essential = packageDictionary[@"Essential"];
-        sqlite3_bind_text(statement, ZBPackageColumnFilename + 1, package[ZBPackageColumnFilename], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBPackageColumnHomepageURL + 1, package[ZBPackageColumnHomepageURL], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBPackageColumnIconURL + 1, package[ZBPackageColumnIconURL], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_int(statement, ZBPackageColumnInstalledSize + 1, atoi(package[ZBPackageColumnInstalledSize]));
+    sqlite3_bind_text(statement, ZBPackageColumnFilename + 1, package[ZBPackageColumnFilename], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBPackageColumnHomepageURL + 1, package[ZBPackageColumnHomepageURL], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBPackageColumnIconURL + 1, package[ZBPackageColumnIconURL], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, ZBPackageColumnInstalledSize + 1, atoi(package[ZBPackageColumnInstalledSize]));
+    
+    char *maintainer = package[ZBPackageColumnMaintainerName];
+    emailBegin = strchr(maintainer, '<');
+    emailEnd = strchr(maintainer, '>');
+    if (emailBegin && emailEnd) {
+        char *email = (char *)malloc(emailEnd - emailBegin);
+        memcpy(email, emailBegin + 1, emailEnd - emailBegin - 1);
+        email[emailEnd - emailBegin - 1] = 0;
         
-        char *maintainer = package[ZBPackageColumnMaintainerName];
-        emailBegin = strchr(maintainer, '<');
-        emailEnd = strchr(maintainer, '>');
-        if (emailBegin && emailEnd) {
-            char *email = (char *)malloc(emailEnd - emailBegin);
-            memcpy(email, emailBegin + 1, emailEnd - emailBegin - 1);
-            email[emailEnd - emailBegin - 1] = 0;
-            
-            if (maintainer < emailBegin && *(emailBegin - 1) == ' ') {
-                emailBegin--;
-            }
-            *emailBegin = 0;
-            
-            if (strcmp(maintainer, "") == 0) { // If somehow the package maintainer messed up the email...
-                strcpy(maintainer, email);
-            }
-            sqlite3_bind_text(statement, ZBPackageColumnMaintainerName + 1, author, -1, SQLITE_TRANSIENT);
-            sqlite3_bind_text(statement, ZBPackageColumnMaintainerEmail + 1, email, -1, SQLITE_TRANSIENT);
-            free(email);
-        } else {
-            sqlite3_bind_text(statement, ZBPackageColumnMaintainerName + 1, maintainer, -1, SQLITE_TRANSIENT);
-            sqlite3_bind_null(statement, ZBPackageColumnMaintainerEmail + 1);
+        if (maintainer < emailBegin && *(emailBegin - 1) == ' ') {
+            emailBegin--;
         }
+        *emailBegin = 0;
         
-        sqlite3_bind_text(statement, ZBPackageColumnDescription + 1, package[ZBPackageColumnDescription], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBPackageColumnPriority + 1, package[ZBPackageColumnPriority], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBPackageColumnProvides + 1, package[ZBPackageColumnProvides], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBPackageColumnReplaces + 1, package[ZBPackageColumnReplaces], -1, SQLITE_TRANSIENT);
-        
-        int roleValue = 0;
-        char *tag = package[ZBPackageColumnTag];
-        if (tag && tag[0] != '\0') {
-            char *roleTag = strstr(tag, "role::");
-            if (roleTag) {
-                char *begin = roleTag + 6;
-                char *end = strchr(roleTag, ',') ?: strchr(roleTag, '\0');
-                
-                size_t size = end - begin;
-                char *role = malloc(size + 1 * sizeof(char));
-                strncpy(role, begin, size);
-                role[size] = '\0';
-                
-                if (strcmp(role, "user") == 0 || strcmp(role, "enduser") == 0) roleValue = 0;
-                else if (strcmp(role, "hacker") == 0) roleValue = 1;
-                else if (strcmp(role, "developer") == 0) roleValue = 2;
-                else if (strcmp(role, "cydia") == 0 || strcmp(role, "goddess") == 0) roleValue = 3;
-                else roleValue = 0;
-                
-                free(role);
-            }
+        if (strcmp(maintainer, "") == 0) { // If somehow the package maintainer messed up the email...
+            strcpy(maintainer, email);
         }
-        sqlite3_bind_int(statement, ZBPackageColumnRole + 1, roleValue);
-        
-        sqlite3_bind_text(statement, ZBPackageColumnSection + 1, package[ZBPackageColumnSection], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBPackageColumnSHA256 + 1, package[ZBPackageColumnSHA256], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBPackageColumnTag + 1, package[ZBPackageColumnTag], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBPackageColumnVersion + 1, package[ZBPackageColumnVersion], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBPackageColumnSource + 1, package[ZBPackageColumnSource], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBPackageColumnUUID + 1, package[ZBPackageColumnUUID], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_int64(statement, ZBPackageColumnLastSeen + 1, *(int *)package[ZBPackageColumnLastSeen]);
-        
+        sqlite3_bind_text(statement, ZBPackageColumnMaintainerName + 1, author, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(statement, ZBPackageColumnMaintainerEmail + 1, email, -1, SQLITE_TRANSIENT);
+        free(email);
+    } else {
+        sqlite3_bind_text(statement, ZBPackageColumnMaintainerName + 1, maintainer, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_null(statement, ZBPackageColumnMaintainerEmail + 1);
+    }
+    
+    sqlite3_bind_text(statement, ZBPackageColumnDescription + 1, package[ZBPackageColumnDescription], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBPackageColumnPriority + 1, package[ZBPackageColumnPriority], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBPackageColumnProvides + 1, package[ZBPackageColumnProvides], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBPackageColumnReplaces + 1, package[ZBPackageColumnReplaces], -1, SQLITE_TRANSIENT);
+    
+    int roleValue = 0;
+    char *tag = package[ZBPackageColumnTag];
+    if (tag && tag[0] != '\0') {
+        char *roleTag = strstr(tag, "role::");
+        if (roleTag) {
+            char *begin = roleTag + 6;
+            char *end = strchr(roleTag, ',') ?: strchr(roleTag, '\0');
+            
+            size_t size = end - begin;
+            char *role = malloc(size + 1 * sizeof(char));
+            strncpy(role, begin, size);
+            role[size] = '\0';
+            
+            if (strcmp(role, "user") == 0 || strcmp(role, "enduser") == 0) roleValue = 0;
+            else if (strcmp(role, "hacker") == 0) roleValue = 1;
+            else if (strcmp(role, "developer") == 0) roleValue = 2;
+            else if (strcmp(role, "cydia") == 0 || strcmp(role, "goddess") == 0) roleValue = 3;
+            else roleValue = 0;
+            
+            free(role);
+        }
+    }
+    sqlite3_bind_int(statement, ZBPackageColumnRole + 1, roleValue);
+    
+    sqlite3_bind_text(statement, ZBPackageColumnSection + 1, package[ZBPackageColumnSection], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBPackageColumnSHA256 + 1, package[ZBPackageColumnSHA256], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBPackageColumnTag + 1, package[ZBPackageColumnTag], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBPackageColumnVersion + 1, package[ZBPackageColumnVersion], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBPackageColumnSource + 1, package[ZBPackageColumnSource], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBPackageColumnUUID + 1, package[ZBPackageColumnUUID], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int64(statement, ZBPackageColumnLastSeen + 1, *(int *)package[ZBPackageColumnLastSeen]);
+    
+    @synchronized (self) {
         int result = sqlite3_step(statement);
         if (result != SQLITE_DONE) {
             ZBLog(@"[Zebra] Failed to insert package into database with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
         }
-        
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-    });
+    }
+    
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
 }
 
 - (void)deletePackagesWithUniqueIdentifiers:(NSSet *)uniqueIdentifiers {
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeRemovePackageWithUUID];
-        int result = [self beginTransaction];
+    sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeRemovePackageWithUUID];
+    
+    [self performTransaction:^{
         for (NSString *uuid in uniqueIdentifiers) {
-            result = sqlite3_bind_text(statement, 1, [uuid UTF8String], -1, SQLITE_TRANSIENT);
+            int result = sqlite3_bind_text(statement, 1, [uuid UTF8String], -1, SQLITE_TRANSIENT);
             if (result == SQLITE_OK) {
                 result = sqlite3_step(statement);
-                
                 if (result != SQLITE_DONE) {
                     ZBLog(@"[Zebra] Failed to delete package with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
                 }
@@ -1401,42 +1299,38 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
             sqlite3_clear_bindings(statement);
             sqlite3_reset(statement);
         }
-        
-        [self endTransaction];
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-    });
+    }];
 }
 
 #pragma mark - Source Management
 
 - (ZBSource *)insertSource:(char **)source {
-    dispatch_sync(databaseQueue, ^{
-        sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeInsertSource];
-        
-        sqlite3_bind_text(statement, ZBSourceColumnArchitectures + 1, source[ZBSourceColumnArchitectures], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBSourceColumnArchiveType + 1, source[ZBSourceColumnArchiveType], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBSourceColumnCodename + 1, source[ZBSourceColumnCodename], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBSourceColumnComponents + 1, source[ZBSourceColumnComponents], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBSourceColumnDistribution + 1, source[ZBSourceColumnDistribution], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBSourceColumnLabel + 1, source[ZBSourceColumnLabel], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBSourceColumnOrigin + 1, source[ZBSourceColumnOrigin], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBSourceColumnPaymentEndpoint + 1, source[ZBSourceColumnPaymentEndpoint], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBSourceColumnDescription + 1, source[ZBSourceColumnDescription], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBSourceColumnSuite + 1, source[ZBSourceColumnSuite], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_int(statement, ZBSourceColumnSupportsFeaturedPackages + 1, *(int *)source[ZBSourceColumnSupportsFeaturedPackages]);
-        sqlite3_bind_text(statement, ZBSourceColumnURL + 1, source[ZBSourceColumnURL], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBSourceColumnUUID + 1, source[ZBSourceColumnUUID], -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, ZBSourceColumnVersion + 1, source[ZBSourceColumnVersion], -1, SQLITE_TRANSIENT);
-        
+    sqlite3_stmt *statement = [self preparedStatementOfType:ZBDatabaseStatementTypeInsertSource];
+    
+    sqlite3_bind_text(statement, ZBSourceColumnArchitectures + 1, source[ZBSourceColumnArchitectures], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBSourceColumnArchiveType + 1, source[ZBSourceColumnArchiveType], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBSourceColumnCodename + 1, source[ZBSourceColumnCodename], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBSourceColumnComponents + 1, source[ZBSourceColumnComponents], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBSourceColumnDistribution + 1, source[ZBSourceColumnDistribution], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBSourceColumnLabel + 1, source[ZBSourceColumnLabel], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBSourceColumnOrigin + 1, source[ZBSourceColumnOrigin], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBSourceColumnPaymentEndpoint + 1, source[ZBSourceColumnPaymentEndpoint], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBSourceColumnDescription + 1, source[ZBSourceColumnDescription], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBSourceColumnSuite + 1, source[ZBSourceColumnSuite], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, ZBSourceColumnSupportsFeaturedPackages + 1, *(int *)source[ZBSourceColumnSupportsFeaturedPackages]);
+    sqlite3_bind_text(statement, ZBSourceColumnURL + 1, source[ZBSourceColumnURL], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBSourceColumnUUID + 1, source[ZBSourceColumnUUID], -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, ZBSourceColumnVersion + 1, source[ZBSourceColumnVersion], -1, SQLITE_TRANSIENT);
+    
+    @synchronized (self) {
         int result = sqlite3_step(statement);
         if (result != SQLITE_DONE) {
             ZBLog(@"[Zebra] Failed to insert source into database with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
         }
-        
-        sqlite3_clear_bindings(statement);
-        sqlite3_reset(statement);
-    });
+    }
+    
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
     
     NSString *uuid = [NSString stringWithUTF8String:source[ZBSourceColumnUUID]];
     return [self sourceWithUUID:uuid];
@@ -1447,13 +1341,13 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
 }
 
 - (void)deleteSource:(ZBSource *)source {
-    dispatch_async(databaseQueue, ^{
+    @synchronized (self) {
         const char *sourceDeleteQuery = [NSString stringWithFormat:@"DELETE FROM " SOURCES_TABLE_NAME " WHERE uuid = \'%@\'", source.uuid].UTF8String;
         sqlite3_exec(self->database, sourceDeleteQuery, nil, nil, nil);
         
         const char *packageDeleteQuery = [NSString stringWithFormat:@"DELETE FROM " PACKAGES_TABLE_NAME " WHERE source = \'%@\'", source.uuid].UTF8String;
         sqlite3_exec(self->database, packageDeleteQuery, nil, nil, nil);
-    });
+    }
 }
 
 #pragma mark - Dependency Resolution

--- a/Zebra/Managers/ZBDatabaseManager.m
+++ b/Zebra/Managers/ZBDatabaseManager.m
@@ -1409,7 +1409,7 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
     });
     
     currentSearchBlock = searchBlock;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), databaseQueue, searchBlock);
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), searchQueue, searchBlock);
 }
 
 #pragma mark - Dependency Resolution

--- a/Zebra/Managers/ZBDatabaseManager.m
+++ b/Zebra/Managers/ZBDatabaseManager.m
@@ -450,9 +450,11 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
 
 - (void)performTransaction:(void (^)(void))transaction {
     @synchronized (self) {
+        NSLog(@"Start Transaction");
         if ([self beginTransaction] != SQLITE_OK) return;
         transaction();
         [self endTransaction];
+        NSLog(@"End Transaction");
     }
 }
 
@@ -1273,11 +1275,9 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
     sqlite3_bind_text(statement, ZBPackageColumnUUID + 1, package[ZBPackageColumnUUID], -1, SQLITE_TRANSIENT);
     sqlite3_bind_int64(statement, ZBPackageColumnLastSeen + 1, *(int *)package[ZBPackageColumnLastSeen]);
     
-    @synchronized (self) {
-        int result = sqlite3_step(statement);
-        if (result != SQLITE_DONE) {
-            ZBLog(@"[Zebra] Failed to insert package into database with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
-        }
+    int result = sqlite3_step(statement);
+    if (result != SQLITE_DONE) {
+        ZBLog(@"[Zebra] Failed to insert package into database with error %d (%s, %d)", result, sqlite3_errmsg(database), sqlite3_extended_errcode(database));
     }
     
     sqlite3_clear_bindings(statement);

--- a/Zebra/Managers/ZBPackageManager.h
+++ b/Zebra/Managers/ZBPackageManager.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isPackageInstalled:(ZBBasePackage *)package;
 - (BOOL)isPackageInstalled:(ZBBasePackage *)package checkVersion:(BOOL)checkVersion;
 - (void)importPackagesFromSource:(ZBBaseSource *)source;
-- (void)packagesFromSource:(ZBSource *)source inSection:(NSString *_Nullable)section completion:(void (^)(NSArray <ZBPackage *> *packages))completion;
+- (void)fetchPackagesFromSource:(ZBSource *)source inSection:(NSString *_Nullable)section completion:(void (^)(NSArray <ZBPackage *> *packages))completion;
 - (NSArray <ZBPackage *> *)latestPackages:(NSUInteger)limit;
 
 - (ZBPackage *_Nullable)installedInstanceOfPackage:(ZBPackage *)package;

--- a/Zebra/Managers/ZBPackageManager.m
+++ b/Zebra/Managers/ZBPackageManager.m
@@ -56,7 +56,7 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (void)packagesFromSource:(ZBSource *)source inSection:(NSString * _Nullable)section completion:(void (^)(NSArray <ZBPackage *> *packages))completion {
+- (void)fetchPackagesFromSource:(ZBSource *)source inSection:(NSString * _Nullable)section completion:(void (^)(NSArray <ZBPackage *> *packages))completion {
     if ([section isEqual:@"Uncategorized"]) section = @"";
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
         NSArray *packages = [self->databaseManager packagesFromSource:source inSection:section];

--- a/Zebra/UI/Packages/ZBPackageListViewController.m
+++ b/Zebra/UI/Packages/ZBPackageListViewController.m
@@ -141,7 +141,7 @@
             });
         });
     } else { // Load packages for the first time, every other access is done by filter
-        [packageManager packagesFromSource:self.source inSection:self.section completion:^(NSArray<ZBPackage *> * _Nonnull packages) {
+        [packageManager fetchPackagesFromSource:self.source inSection:self.section completion:^(NSArray<ZBPackage *> * _Nonnull packages) {
             self.packages = packages;
             if ([self.source.uuid isEqualToString:@"_var_lib_dpkg_status_"]) {
                 self->updates = self->packageManager.updates;


### PR DESCRIPTION
With the database improvements, Zebra was often moving too fast in order to keep up with several database reads/writes at once. This PR attempts to slow things down a bit so that sequential reads/writes are preformed on the database and hopefully solves any crashes with database memory access.

In order to fix database corruptions in version 1 of the database, we force a migration to version 2.

Aims to solve #1682, #1667, and #1657