### PR TITLE
[Packages] Fix packages by author returning empty list from Depiction page

### DIFF
--- a/Zebra/Managers/ZBDatabaseManager.h
+++ b/Zebra/Managers/ZBDatabaseManager.h
@@ -65,15 +65,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (ZBPackage *_Nullable)installedInstanceOfPackage:(ZBPackage *)package;
 
 /*!
- @brief Get instances of packages by an author
- @discussion This array is full of ZBBasePackage instances, a ZBBasePackage instance will forward unknown selectors to a ZBPackage instance using -packageWithUniqueIdentifier: so either class behaves the same.
- @param name The author's name.
- @param email The author's email (optional).
- @return An array of instances that are created by the author
- */
-- (NSArray <ZBPackage *> *)packagesByAuthorWithName:(NSString *)name email:(NSString *_Nullable)email;
-
-/*!
  @brief The latest packages imported to the database
  @param limit How many package to retrieve from the database. -1 or UINT_MAX will return all packages available.
  @return The latest packages imported to the database limited by the limit parameter.
@@ -108,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)searchForPackagesByName:(NSString *)name completion:(void (^)(NSArray <ZBPackage *> *packages))completion;
 - (void)searchForPackagesByDescription:(NSString *)description completion:(void (^)(NSArray <ZBPackage *> *packages))completion;
-- (void)searchForPackagesByAuthorWithName:(NSString *)name completion:(void (^)(NSArray <ZBPackage *> *packages))completion;
+- (void)searchForPackagesByAuthorWithName:(NSString *)name email:(NSString *_Nullable)email completion:(void (^)(NSArray <ZBPackage *> *packages))completion;
 
 #pragma mark - Source Retrieval
 

--- a/Zebra/Managers/ZBPackageManager.h
+++ b/Zebra/Managers/ZBPackageManager.h
@@ -32,13 +32,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray <NSString *> *)allVersionsOfPackage:(ZBPackage *)package;
 - (NSArray <ZBPackage *> *)allInstancesOfPackage:(ZBPackage *)package;
 - (ZBPackage *_Nullable)packageWithUniqueIdentifier:(NSString *)uuid;
-- (NSArray <ZBPackage *> *)packagesByAuthorWithName:(NSString *)name email:(NSString *_Nullable)email;
 
 - (BOOL)canReinstallPackage:(ZBPackage *)package;
 
 - (void)searchForPackagesByName:(NSString *)name completion:(void (^)(NSArray <ZBPackage *> *packages))completion;
 - (void)searchForPackagesByDescription:(NSString *)description completion:(void (^)(NSArray <ZBPackage *> *packages))completion;
-- (void)searchForPackagesByAuthorWithName:(NSString *)name completion:(void (^)(NSArray <ZBPackage *> *packages))completion;
+- (void)searchForPackagesByAuthorWithName:(NSString *)name email:(NSString *_Nullable)email completion:(void (^)(NSArray <ZBPackage *> *packages))completion;
 
 - (NSString *)installedVersionOfPackage:(ZBPackage *)package;
 

--- a/Zebra/Managers/ZBPackageManager.m
+++ b/Zebra/Managers/ZBPackageManager.m
@@ -250,10 +250,6 @@
     return [databaseManager packageWithUniqueIdentifier:uuid];
 }
 
-- (NSArray <ZBPackage *> *)packagesByAuthorWithName:(NSString *)name email:(NSString *_Nullable)email {
-    return [databaseManager packagesByAuthorWithName:name email:email];
-}
-
 - (BOOL)canReinstallPackage:(ZBPackage *)package {
     return [databaseManager isPackageAvailable:package checkVersion:YES];
 }
@@ -266,8 +262,8 @@
     [databaseManager searchForPackagesByDescription:description completion:completion];
 }
 
-- (void)searchForPackagesByAuthorWithName:(NSString *)name completion:(void (^)(NSArray <ZBPackage *> *packages))completion {
-    [databaseManager searchForPackagesByAuthorWithName:name completion:completion];
+- (void)searchForPackagesByAuthorWithName:(NSString *)name email:(NSString *_Nullable)email completion:(void (^)(NSArray <ZBPackage *> *packages))completion {
+    [databaseManager searchForPackagesByAuthorWithName:name email:email completion:completion];
 }
 
 - (NSString *)installedVersionOfPackage:(ZBPackage *)package {

--- a/Zebra/Tabs/Packages/Controllers/ZBPackagesByAuthorTableViewController.m
+++ b/Zebra/Tabs/Packages/Controllers/ZBPackagesByAuthorTableViewController.m
@@ -20,7 +20,7 @@
 #import <Managers/ZBPackageManager.h>
 
 @interface ZBPackagesByAuthorTableViewController () {
-    NSArray *moreByAuthor;
+    NSArray <ZBPackage *> *moreByAuthor;
     ZBPackage *package;
 }
 @end
@@ -39,7 +39,12 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    moreByAuthor = [[ZBPackageManager sharedInstance] packagesByAuthorWithName:package.authorName email:package.authorEmail];
+    [[ZBPackageManager sharedInstance] searchForPackagesByAuthorWithName:package.authorName email:package.authorEmail completion:^(NSArray <ZBPackage *> *packages) {
+        self->moreByAuthor = packages;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.tableView reloadData];
+        });
+    }];
     [self.tableView registerNib:[UINib nibWithNibName:@"ZBPackageTableViewCell" bundle:nil] forCellReuseIdentifier:@"packageTableViewCell"];
     self.navigationItem.title = package.authorName;
     self.tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectZero];

--- a/Zebra/UI/Search/ZBSearchViewController.m
+++ b/Zebra/UI/Search/ZBSearchViewController.m
@@ -139,7 +139,7 @@
             break;
         }
         case 2: {
-            [packageManager searchForPackagesByAuthorWithName:strippedString completion:^(NSArray<ZBPackage *> * _Nonnull packages) {
+            [packageManager searchForPackagesByAuthorWithName:strippedString email:nil completion:^(NSArray<ZBPackage *> * _Nonnull packages) {
                 updateTable(packages);
             }];
             break;


### PR DESCRIPTION
Addresses #1654 

This PR adds a new query statement type: `ZBDatabaseStatementTypeSearchForPackageByAuthorNameAndEmail`. Here, you supply the full author name and email, unlike `ZBDatabaseStatementTypeSearchForPackageByAuthorName` that accepts a partial string of the likes of the author name.

This PR removes a now obsoleted method `-packagesByAuthorWithName:email:`and replaces it with the existing method with an additional `email` parameter known as `-searchForPackagesByAuthorWithName:email:completion:`.