### PR TITLE
[Packages] Various swipe action fixes

### DIFF
--- a/Zebra/Managers/ZBDatabaseManager.h
+++ b/Zebra/Managers/ZBDatabaseManager.h
@@ -79,6 +79,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (ZBPackage *_Nullable)remoteInstanceOfPackage:(ZBPackage *)package withVersion:(NSString *)version;
 
+- (NSArray <ZBPackage *> *)allRemoteInstancesOfPackage:(ZBPackage *)package withVersion:(NSString *)version;
+
 - (NSDictionary <NSString *,NSString *> *)installedPackages;
 
 #pragma mark - Package Information

--- a/Zebra/Managers/ZBPackageManager.h
+++ b/Zebra/Managers/ZBPackageManager.h
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (ZBPackage *_Nullable)installedInstanceOfPackage:(ZBPackage *)package;
 - (ZBPackage *_Nullable)remoteInstanceOfPackage:(ZBPackage *)package withVersion:(NSString *)version;
+- (NSArray <ZBPackage *> *)allRemoteInstancesOfPackage:(ZBPackage *)package withVersion:(NSString *)version;
 - (NSArray <NSString *> *)allVersionsOfPackage:(ZBPackage *)package;
 - (NSArray <ZBPackage *> *)allInstancesOfPackage:(ZBPackage *)package;
 - (ZBPackage *_Nullable)packageWithUniqueIdentifier:(NSString *)uuid;

--- a/Zebra/Managers/ZBPackageManager.m
+++ b/Zebra/Managers/ZBPackageManager.m
@@ -298,6 +298,10 @@
     return [databaseManager remoteInstanceOfPackage:package withVersion:version];
 }
 
+- (NSArray <ZBPackage *> *)allRemoteInstancesOfPackage:(ZBPackage *)package withVersion:(NSString *)version {
+    return [databaseManager allRemoteInstancesOfPackage:package withVersion:version];
+}
+
 - (NSUInteger)numberOfInstalledPackagesFromSource:(ZBSource *)source {
     return [self.installedPackages.allValues filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"SELF like %@", source.uuid]].count;
 }

--- a/Zebra/Tabs/Packages/Helpers/ZBPackageActions.m
+++ b/Zebra/Tabs/Packages/Helpers/ZBPackageActions.m
@@ -183,7 +183,8 @@
 }
 
 + (void)reinstall:(ZBPackage *)package completion:(void (^)(void))completion {
-    ZBPackage *candidate = [[ZBPackageManager sharedInstance] remoteInstanceOfPackage:package withVersion:package.version];
+    NSString *installedVersion = [[ZBPackageManager sharedInstance] installedVersionOfPackage:package];
+    ZBPackage *candidate = [[ZBPackageManager sharedInstance] remoteInstanceOfPackage:package withVersion:installedVersion];
     if (candidate) {
         [[ZBQueue sharedQueue] addPackage:candidate toQueue:ZBQueueTypeReinstall];
         if (completion) completion();
@@ -221,7 +222,8 @@
 }
 
 + (void)upgrade:(ZBPackage *)package completion:(void (^)(void))completion {
-    NSArray <NSString *> *greaterVersions = package.greaterVersions;
+    ZBPackage *installedPackage = [[ZBPackageManager sharedInstance] installedInstanceOfPackage:package];
+    NSArray <NSString *> *greaterVersions = installedPackage.greaterVersions;
     if (greaterVersions.count > 1) {
         UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Select Version", @"") message:NSLocalizedString(@"Select a version to upgrade to:", @"") preferredStyle:[self alertControllerStyle]];
         
@@ -257,7 +259,8 @@
 }
 
 + (void)downgrade:(ZBPackage *)package completion:(void (^)(void))completion {
-    NSArray <NSString *> *lesserVersions = package.lesserVersions;
+    ZBPackage *installedPackage = [[ZBPackageManager sharedInstance] installedInstanceOfPackage:package];
+    NSArray <NSString *> *lesserVersions = installedPackage.lesserVersions;
     if (lesserVersions.count > 1) {
         UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Select Version", @"") message:NSLocalizedString(@"Select a version to downgrade to:", @"") preferredStyle:[self alertControllerStyle]];
         

--- a/Zebra/Tabs/Packages/Helpers/ZBPackageActions.m
+++ b/Zebra/Tabs/Packages/Helpers/ZBPackageActions.m
@@ -196,20 +196,44 @@
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Select Version", @"") message:NSLocalizedString(@"Select a version to install:", @"") preferredStyle:[self alertControllerStyle]];
     
     NSCountedSet *versionStrings = [[NSCountedSet alloc] initWithArray:allVersions];
-    for (NSString *otherVersion in allVersions) {
+    NSOrderedSet *deduplicatedVersions = [[NSOrderedSet alloc] initWithArray:allVersions];
+    for (NSString *otherVersion in deduplicatedVersions) {
         NSString *title;
-        if ([otherVersion isEqual:allVersions[0]]) {
+        if ([otherVersion isEqual:allVersions.firstObject]) {
             title = [NSString stringWithFormat:@"%@ (%@)", NSLocalizedString(@"Latest", @""), otherVersion];
         } else {
-            title = [versionStrings countForObject:otherVersion] > 1 ? [NSString stringWithFormat:@"%@ (%@)", otherVersion, package.source.label] : otherVersion;
+            title = [versionStrings countForObject:otherVersion] > 1 ? [NSString stringWithFormat:@"%@ (%@)", otherVersion, NSLocalizedString(@"In Multiple Sources", @"")] : otherVersion;
         }
-        UIAlertAction *action = [UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-            ZBPackage *otherPackage = [[ZBPackageManager sharedInstance] remoteInstanceOfPackage:package withVersion:otherVersion];
-            otherPackage.requiresAuthorization = package.requiresAuthorization;
-            [[ZBQueue sharedQueue] addPackage:otherPackage toQueue:ZBQueueTypeInstall];
-            
-            if (completion) completion();
-        }];
+        UIAlertAction *action;
+        if ([versionStrings countForObject:otherVersion] > 1) {
+            action = [UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+                NSArray <ZBPackage *> *otherPackages = [[ZBPackageManager sharedInstance] allRemoteInstancesOfPackage:package withVersion:otherVersion];
+
+                UIAlertController *sourceAlert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Select Source", @"") message:NSLocalizedString(@"Select a source to install the package from:", @"") preferredStyle:[self alertControllerStyle]];
+
+                for (ZBPackage *otherPackage in otherPackages) {
+                    UIAlertAction *sourceAction = [UIAlertAction actionWithTitle:[NSString stringWithFormat:@"%@", otherPackage.source.label] style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+                        otherPackage.requiresAuthorization = package.requiresAuthorization;
+                        [[ZBQueue sharedQueue] addPackage:otherPackage toQueue:ZBQueueTypeInstall];
+
+                        if (completion) completion();
+                    }];
+                    [sourceAlert addAction:sourceAction];
+                }
+                UIAlertAction *cancel = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"") style:UIAlertActionStyleCancel handler:nil];
+                [sourceAlert addAction:cancel];
+
+                [sourceAlert show];
+            }];
+        } else {
+            action = [UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+                ZBPackage *otherPackage = [[ZBPackageManager sharedInstance] remoteInstanceOfPackage:package withVersion:otherVersion];
+                otherPackage.requiresAuthorization = package.requiresAuthorization;
+                [[ZBQueue sharedQueue] addPackage:otherPackage toQueue:ZBQueueTypeInstall];
+
+                if (completion) completion();
+            }];
+        }
         
         [alert addAction:action];
     }
@@ -228,15 +252,40 @@
         UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Select Version", @"") message:NSLocalizedString(@"Select a version to upgrade to:", @"") preferredStyle:[self alertControllerStyle]];
         
         NSCountedSet *versionStrings = [[NSCountedSet alloc] initWithArray:greaterVersions];
-        for (NSString *otherVersion in greaterVersions) {
-            NSString *title = [versionStrings countForObject:otherVersion] > 1 ? [NSString stringWithFormat:@"%@ (%@)", otherVersion, package.source.label] : otherVersion;
-            UIAlertAction *action = [UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                ZBPackage *otherPackage = [[ZBPackageManager sharedInstance] remoteInstanceOfPackage:package withVersion:otherVersion];
-                otherPackage.requiresAuthorization = package.requiresAuthorization;
-                [[ZBQueue sharedQueue] addPackage:otherPackage toQueue:ZBQueueTypeUpgrade];
-                
-                if (completion) completion();
-            }];
+        NSOrderedSet *deduplicatedVersions = [[NSOrderedSet alloc] initWithArray:greaterVersions];
+        for (NSString *otherVersion in deduplicatedVersions) {
+            NSString *title = [versionStrings countForObject:otherVersion] > 1 ? [NSString stringWithFormat:@"%@ (%@)", otherVersion, NSLocalizedString(@"In Multiple Sources", @"")] : otherVersion;
+
+            UIAlertAction *action;
+            if ([versionStrings countForObject:otherVersion] > 1) {
+                action = [UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+                    NSArray <ZBPackage *> *otherPackages = [[ZBPackageManager sharedInstance] allRemoteInstancesOfPackage:package withVersion:otherVersion];
+
+                    UIAlertController *sourceAlert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Select Source", @"") message:NSLocalizedString(@"Select a source to upgrade the package from:", @"") preferredStyle:[self alertControllerStyle]];
+
+                    for (ZBPackage *otherPackage in otherPackages) {
+                        UIAlertAction *sourceAction = [UIAlertAction actionWithTitle:[NSString stringWithFormat:@"%@", otherPackage.source.label] style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+                            otherPackage.requiresAuthorization = package.requiresAuthorization;
+                            [[ZBQueue sharedQueue] addPackage:otherPackage toQueue:ZBQueueTypeUpgrade];
+
+                            if (completion) completion();
+                        }];
+                        [sourceAlert addAction:sourceAction];
+                    }
+                    UIAlertAction *cancel = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"") style:UIAlertActionStyleCancel handler:nil];
+                    [sourceAlert addAction:cancel];
+
+                    [sourceAlert show];
+                }];
+            } else {
+                action = [UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+                    ZBPackage *otherPackage = [[ZBPackageManager sharedInstance] remoteInstanceOfPackage:package withVersion:otherVersion];
+                    otherPackage.requiresAuthorization = package.requiresAuthorization;
+                    [[ZBQueue sharedQueue] addPackage:otherPackage toQueue:ZBQueueTypeUpgrade];
+
+                    if (completion) completion();
+                }];
+            }
             
             [alert addAction:action];
         }
@@ -265,15 +314,39 @@
         UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Select Version", @"") message:NSLocalizedString(@"Select a version to downgrade to:", @"") preferredStyle:[self alertControllerStyle]];
         
         NSCountedSet *versionStrings = [[NSCountedSet alloc] initWithArray:lesserVersions];
-        for (NSString *otherVersion in lesserVersions) {
-            NSString *title = [versionStrings countForObject:otherVersion] > 1 ? [NSString stringWithFormat:@"%@ (%@)", otherVersion, package.source.label] : otherVersion;
-            UIAlertAction *action = [UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                ZBPackage *otherPackage = [[ZBPackageManager sharedInstance] remoteInstanceOfPackage:package withVersion:otherVersion];
-                otherPackage.requiresAuthorization = package.requiresAuthorization;
-                [[ZBQueue sharedQueue] addPackage:otherPackage toQueue:ZBQueueTypeDowngrade];
-                
-                if (completion) completion();
-            }];
+        NSOrderedSet *deduplicatedVersions = [[NSOrderedSet alloc] initWithArray:lesserVersions];
+        for (NSString *otherVersion in deduplicatedVersions) {
+            NSString *title = [versionStrings countForObject:otherVersion] > 1 ? [NSString stringWithFormat:@"%@ (%@)", otherVersion, NSLocalizedString(@"In Multiple Sources", @"")] : otherVersion;
+            UIAlertAction *action;
+            if ([versionStrings countForObject:otherVersion] > 1) {
+                action = [UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+                    NSArray <ZBPackage *> *otherPackages = [[ZBPackageManager sharedInstance] allRemoteInstancesOfPackage:package withVersion:otherVersion];
+
+                    UIAlertController *sourceAlert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Select Source", @"") message:NSLocalizedString(@"Select a source to downgrade the package from:", @"") preferredStyle:[self alertControllerStyle]];
+
+                    for (ZBPackage *otherPackage in otherPackages) {
+                        UIAlertAction *sourceAction = [UIAlertAction actionWithTitle:[NSString stringWithFormat:@"%@", otherPackage.source.label] style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+                            otherPackage.requiresAuthorization = package.requiresAuthorization;
+                            [[ZBQueue sharedQueue] addPackage:otherPackage toQueue:ZBQueueTypeDowngrade];
+
+                            if (completion) completion();
+                        }];
+                        [sourceAlert addAction:sourceAction];
+                    }
+                    UIAlertAction *cancel = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"") style:UIAlertActionStyleCancel handler:nil];
+                    [sourceAlert addAction:cancel];
+
+                    [sourceAlert show];
+                }];
+            } else {
+                action = [UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+                    ZBPackage *otherPackage = [[ZBPackageManager sharedInstance] remoteInstanceOfPackage:package withVersion:otherVersion];
+                    otherPackage.requiresAuthorization = package.requiresAuthorization;
+                    [[ZBQueue sharedQueue] addPackage:otherPackage toQueue:ZBQueueTypeDowngrade];
+
+                    if (completion) completion();
+                }];
+            }
             
             [alert addAction:action];
         }

--- a/Zebra/Tabs/Packages/Helpers/ZBPackageActions.m
+++ b/Zebra/Tabs/Packages/Helpers/ZBPackageActions.m
@@ -422,13 +422,7 @@
         NSString *title = [self titleForAction:action useIcon:YES];
         UIContextualActionStyle style = action == ZBPackageActionRemove ? UIContextualActionStyleDestructive : UIContextualActionStyleNormal;
         UIContextualAction *swipeAction = [UIContextualAction contextualActionWithStyle:style title:title handler:^(UIContextualAction * _Nonnull contextualAction, __kindof UIView * _Nonnull sourceView, void (^ _Nonnull completionHandler)(BOOL)) {
-            [self performAction:action forPackage:package completion:^{
-                if (tableView) {
-                    dispatch_async(dispatch_get_main_queue(), ^{
-                        [tableView reloadRowsAtIndexPaths:[tableView indexPathsForVisibleRows] withRowAnimation:UITableViewRowAnimationNone];
-                    });
-                }
-            }];
+            [self performAction:action forPackage:package completion:nil];
             completionHandler(YES);
         }];
 


### PR DESCRIPTION
This pull request aims to resolve some issues with the package swipe actions:
- Fix the crash when triggering a swipe action on the packages tab
- Always base the change calculations on the installed version of the package.
- Reimplement the package version choice menu to fix null string and to ensure that the package is downloaded from the correct source.