### PR TITLE
[Sources] Small payment API fixes

### DIFF
--- a/Zebra/Model/ZBPackage.m
+++ b/Zebra/Model/ZBPackage.m
@@ -947,7 +947,7 @@ NSComparisonResult (^versionComparator)(NSString *, NSString *) = ^NSComparisonR
     }
     
     // Should only run if we don't have a payment secret or if we aren't logged in.
-    [[self source] authenticate:^(BOOL success, BOOL notify, NSError * _Nullable error) {
+    [[self source] authenticate:YES completion:^(BOOL success, BOOL notify, NSError * _Nullable error) {
         if (tryAgain && success && !error) {
             [self purchase:NO completion:completion]; // Try again, but only try once
         }

--- a/Zebra/Model/ZBPackage.m
+++ b/Zebra/Model/ZBPackage.m
@@ -947,7 +947,7 @@ NSComparisonResult (^versionComparator)(NSString *, NSString *) = ^NSComparisonR
     }
     
     // Should only run if we don't have a payment secret or if we aren't logged in.
-    [[self source] authenticate:YES completion:^(BOOL success, BOOL notify, NSError * _Nullable error) {
+    [[self source] authenticate:tryAgain completion:^(BOOL success, BOOL notify, NSError * _Nullable error) {
         if (tryAgain && success && !error) {
             [self purchase:NO completion:completion]; // Try again, but only try once
         }

--- a/Zebra/Model/ZBSource.h
+++ b/Zebra/Model/ZBSource.h
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)getPaymentEndpoint:(void (^)(NSURL *_Nullable paymentEndpointURL))completion;
 - (NSString *)paymentSecret:(NSError **)error;
-- (void)authenticate:(void (^)(BOOL success, BOOL notify, NSError *_Nullable error))completion;
+- (void)authenticate:(BOOL)force completion:(void (^)(BOOL success, BOOL notify, NSError *_Nullable error))completion;
 - (void)signOut;
 - (BOOL)isSignedIn;
 - (BOOL)supportsPaymentAPI;

--- a/Zebra/Model/ZBSource.h
+++ b/Zebra/Model/ZBSource.h
@@ -40,7 +40,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Modern Payment API
 
-- (void)getPaymentEndpoint:(void (^)(NSURL *_Nullable paymentEndpointURL))completion;
 - (NSString *)paymentSecret:(NSError **)error;
 - (void)authenticate:(BOOL)force completion:(void (^)(BOOL success, BOOL notify, NSError *_Nullable error))completion;
 - (void)signOut;

--- a/Zebra/Model/ZBSource.m
+++ b/Zebra/Model/ZBSource.m
@@ -187,7 +187,7 @@
     [session start];
 }
 
-- (void)signOut API_AVAILABLE(ios(11.0)) {
+- (void)signOut {
     if (![self supportsPaymentAPI]) {
 //        NSError *error = [NSError errorWithDomain:NSCocoaErrorDomain code:412 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Source does not support Payment API", @"")}];
         return;
@@ -217,7 +217,7 @@
     [signOutTask resume];
 }
 
-- (BOOL)isSignedIn API_AVAILABLE(ios(11.0)) {
+- (BOOL)isSignedIn {
     UICKeyChainStore *keychain = [UICKeyChainStore keyChainStoreWithService:[ZBAppDelegate bundleID] accessGroup:nil];
     return [keychain stringForKey:self.repositoryURI] ? YES : NO;
 }
@@ -330,22 +330,6 @@
     else if (_pinPriority == 0) return 500;
     else return _pinPriority;
 }
-
-//- (void)getPaymentEndpoint:(void (^)(NSURL *))completion {
-//    if (checkedForPaymentEndpoint) completion(paymentEndpointURL);
-//
-//    [[NSURLSession sharedSession] dataTaskWithURL:[self.mainDirectoryURL URLByAppendingPathComponent:@"payment_endpoint"] completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
-//        NSInteger httpStatus = [((NSHTTPURLResponse *)response) statusCode];
-//        if (httpStatus == 200 && !error) {
-//            NSString *response = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-//            if (response) {
-//                self->paymentEndpointURL = [NSURL URLWithString:response];
-//            }
-//        }
-//        self->checkedForPaymentEndpoint = YES;
-//        completion(self->paymentEndpointURL);
-//    }];
-//}
 
 - (void)getFeaturedPackages:(void (^)(NSDictionary *))completion {
     if (self->featuredPackages) completion(featuredPackages);

--- a/Zebra/Model/ZBSource.m
+++ b/Zebra/Model/ZBSource.m
@@ -121,7 +121,7 @@
     return ![[self uuid] isEqualToString:@"getzbra.com_repo_"];
 }
 
-- (void)authenticate:(void (^)(BOOL success, BOOL notify, NSError *_Nullable error))completion {
+- (void)authenticate:(BOOL)force completion:(void (^)(BOOL success, BOOL notify, NSError *_Nullable error))completion {
     if (![self supportsPaymentAPI]) {
         NSError *error = [NSError errorWithDomain:NSCocoaErrorDomain code:412 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Source does not support Payment API", @"")}];
         completion(NO, YES, error);
@@ -129,8 +129,12 @@
     }
     
     if ([self isSignedIn]) {
-        completion(YES, NO, nil);
-        return;
+        if (force) {
+            [self signOut];
+        } else {
+            completion(YES, NO, nil);
+            return;
+        }
     }
     
     NSURLComponents *components = [NSURLComponents componentsWithURL:[self.paymentEndpointURL URLByAppendingPathComponent:@"authenticate"] resolvingAgainstBaseURL:YES];

--- a/Zebra/Model/ZBSource.m
+++ b/Zebra/Model/ZBSource.m
@@ -223,6 +223,8 @@
 }
 
 - (NSString *)paymentSecret:(NSError **)error {
+    return NULL;
+    
     __block NSString *paymentSecret = NULL;
     __block NSError *paymentError = NULL;
     

--- a/Zebra/UI/Sources/ZBSourceViewController.m
+++ b/Zebra/UI/Sources/ZBSourceViewController.m
@@ -175,7 +175,7 @@
 }
 
 - (void)accountButtonPressed:(id)sender {
-    [source authenticate:^(BOOL success, BOOL notify, NSError * _Nullable error) {
+    [source authenticate:NO completion:^(BOOL success, BOOL notify, NSError * _Nullable error) {
         if (!success || error) {
             if (notify) {
                 if (error) {


### PR DESCRIPTION
This PR aims to fix a small bug where a payment secret could not be found from a source and Zebra could not download a package. The behavior is to sign out of the source and try the sign in again but Zebra does not check for payment secrets when the user is already signed in. This bug is solved by forcing the source to sign out if it is signed in so that it can re obtain the payment secret.