### PR TITLE
[Search, Sources] Filter manage-able versions of packages in the packages search results

### DIFF
--- a/Zebra/Managers/ZBDatabaseManager.m
+++ b/Zebra/Managers/ZBDatabaseManager.m
@@ -914,7 +914,7 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
         if (existingPackage) {
             // package and existingPackage are the same packages, one is installed, another is generic
             // If a package added to a temporary list is installed (source = var_lib_dpkg_status_), we discard them and replace with its counterpart which contains more properties for managing packages
-            if ([existingPackage isVersionInstalled]) {
+            if ([existingPackage isInstalled]) {
                 filter[existingPackage.identifier] = package;
             }
         } else {

--- a/Zebra/Managers/ZBDatabaseManager.m
+++ b/Zebra/Managers/ZBDatabaseManager.m
@@ -907,6 +907,23 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
 
 #pragma mark - Package Searching
 
+- (NSArray <ZBPackage *> *)filterDuplicatesOfInstalledPackages:(NSArray <ZBPackage *> *)packages {
+    NSMutableDictionary <NSString *, ZBPackage *> *filter = [NSMutableDictionary new];
+    for (ZBPackage *package in packages) {
+        ZBPackage *existingPackage = filter[package.identifier];
+        if (existingPackage) {
+            // package and existingPackage are the same packages, one is installed, another is generic
+            // If a package added to a temporary list is installed (source = var_lib_dpkg_status_), we discard them and replace with its counterpart which contains more properties for managing packages
+            if ([existingPackage isVersionInstalled]) {
+                filter[existingPackage.identifier] = package;
+            }
+        } else {
+            filter[package.identifier] = package;
+        }
+    }
+    return [filter allValues];
+}
+
 - (void)searchForPackagesByName:(NSString *)name completion:(void (^)(NSArray <ZBPackage *> *packages))completion {
     if (currentSearchBlock) {
         dispatch_block_cancel(currentSearchBlock);
@@ -939,7 +956,7 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
         sqlite3_reset(statement);
         
         if (!dispatch_block_testcancel(searchBlock)) {
-            completion(packages);
+            completion([self filterDuplicatesOfInstalledPackages:packages]);
         }
     });
     
@@ -979,7 +996,7 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
         sqlite3_reset(statement);
         
         if (!dispatch_block_testcancel(searchBlock)) {
-            completion(packages);
+            completion([self filterDuplicatesOfInstalledPackages:packages]);
         }
     });
     
@@ -1023,7 +1040,7 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
         sqlite3_reset(statement);
         
         if (!dispatch_block_testcancel(searchBlock)) {
-            completion(packages);
+            completion([self filterDuplicatesOfInstalledPackages:packages]);
         }
     });
     

--- a/Zebra/Managers/ZBSourceManager.m
+++ b/Zebra/Managers/ZBSourceManager.m
@@ -25,7 +25,7 @@
 @interface ZBSourceManager () {
     NSMutableDictionary <NSString *, NSNumber *> *busyList;
     NSDictionary *pinPreferences;
-    NSDictionary *sourceMap;
+    NSDictionary <NSString *, ZBSource *> *sourceMap;
     
     ZBPackageManager *packageManager;
     ZBDatabaseManager *databaseManager;
@@ -76,13 +76,13 @@ NSString *const ZBSourceDownloadProgressUpdateNotification = @"SourceDownloadPro
 
 #pragma mark - Accessing Sources
 
-- (NSArray <ZBSource *> *)sources {
+- (void)initSources {
     NSError *readError = NULL;
     NSSet *baseSources = [ZBBaseSource baseSourcesFromList:[ZBAppDelegate sourcesListURL] error:&readError];
     if (readError) {
         ZBLog(@"[Zebra] Error when reading sources from %@: %@", [ZBAppDelegate sourcesListURL], readError.localizedDescription);
         
-        return [NSArray new];
+        return;
     }
     
     if (!sourceMap) {
@@ -123,11 +123,17 @@ NSString *const ZBSourceDownloadProgressUpdateNotification = @"SourceDownloadPro
 //            }
 //        });
     }
-    
+}
+
+- (NSArray <ZBSource *> *)sources {
+    [self initSources];
     return [sourceMap allValues];
 }
 
 - (ZBSource *)sourceWithUUID:(NSString *)UUID {
+    if (sourceMap == nil) {
+        [self initSources];
+    }
     return sourceMap[UUID];
 }
 

--- a/Zebra/Model/ZBBasePackage.m
+++ b/Zebra/Model/ZBBasePackage.m
@@ -82,7 +82,7 @@
         }
         
         const char *source = (const char *)sqlite3_column_text(statement, ZBPackageColumnSource);
-        if (source && source) {
+        if (source && source[0] != '\0') {
             self.source = [[ZBSourceManager sharedInstance] sourceWithUUID:[NSString stringWithUTF8String:source]];
         }
         


### PR DESCRIPTION
The way the packages search works now does not take into account the same packages but from different sources. One is installed, hence its source is local. The other is a generic one which has a correct source, more metadata and can be managed correctly.

In this PR, every kind of packages search will be gated by the aforementioned filtering.

Moreover, the other reason of not being to find a download URL of a package to be installed is when the package's `source` is `nil` - and the root cause is `sourceMap` in `ZBSourceManager` is `nil` as we invoke `- (ZBSource *)sourceWithUUID:(NSString *)UUID` method. This PR ensures that this method has access to non-nil source map.

<img width="1166" alt="image" src="https://user-images.githubusercontent.com/3608783/107140472-c5b3db00-6954-11eb-85c7-50fdf6a0e2f7.png">

Closes #1665