### PR TITLE
[Search] Prevent multiple search results updates (UI-wise)

### DIFF
--- a/Zebra/UI/Search/ZBSearchViewController.m
+++ b/Zebra/UI/Search/ZBSearchViewController.m
@@ -25,6 +25,7 @@
     NSArray *searchResults;
     UISearchController *searchController;
     UIActivityIndicatorView *spinner;
+    BOOL isUpdatingResults;
 }
 @end
 
@@ -115,6 +116,8 @@
     void (^updateTable)(NSArray *) = ^void(NSArray *packages) {
         dispatch_async(dispatch_get_main_queue(), ^{
             if (self->spinner.isAnimating) [self hideSpinner];
+            if (self->isUpdatingResults) return;
+            self->isUpdatingResults = YES;
             self->searchResults = packages;
             
             if (packages.count == 0 && strippedString.length != 0) {
@@ -124,6 +127,7 @@
             }
             
             [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:0] withRowAnimation:UITableViewRowAnimationAutomatic];
+            self->isUpdatingResults = NO;
         });
     };
     

--- a/Zebra/UI/Search/ZBSearchViewController.m
+++ b/Zebra/UI/Search/ZBSearchViewController.m
@@ -221,6 +221,7 @@
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
     
+    self->isUpdatingResults = NO;
     if (searchController.active && searchResults.count) {
         ZBPackageViewController *packageController = [[ZBPackageViewController alloc] initWithPackage:searchResults[indexPath.row]];
         [self.navigationController pushViewController:packageController animated:YES];


### PR DESCRIPTION
Sometimes when you keep searching for packages from Search tab. This crash may occur:
```
0       libobjc.A.dylib               	0x1a90a3dd8 0x1a9080000 + 0x23dd8	// objc_release + 0x8
1       CoreFoundation                	0x194c3fb04 0x194c03000 + 0x3cb04	// __RELEASE_OBJECTS_IN_THE_ARRAY__ + 0x70
2       CoreFoundation                	0x194c05ab8 0x194c03000 + 0x2ab8	// -[__NSArrayM dealloc] + 0x110
3     + Zebra (*)                     	0x104cf37d8 0x104cac000 + 0x477d8	// -[ZBBasePackage .cxx_destruct] + 0x54
4       libobjc.A.dylib               	0x1a9085ae0 0x1a9080000 + 0x5ae0	// object_cxxDestructFromClass(objc_object*, objc_class*) + 0x70
5       libobjc.A.dylib               	0x1a909b8a4 0x1a9080000 + 0x1b8a4	// objc_destructInstance + 0x58
6       libobjc.A.dylib               	0x1a90a26ec 0x1a9080000 + 0x226ec	// _objc_rootDealloc + 0x34
7       CoreFoundation                	0x194c1bfa0 0x194c03000 + 0x18fa0	// -[__NSArrayI_Transfer dealloc] + 0x50
8     + Zebra (*)                     	0x104d0756c 0x104cac000 + 0x5b56c	// __65-[ZBSearchViewController updateSearchResultsForSearchController:]_block_invoke_2 + 0x90
9       libdispatch.dylib             	0x194955298 0x1948f5000 + 0x60298	// _dispatch_call_block_and_release + 0x18
```

This PR mitigates it by using a boolean flag to prevent concurrent table UI updates that seem to be the cause of the crash.