### PR TITLE
[Packages] Sort `-[ZBPackage allVersions]`

### DIFF
--- a/Zebra/Model/ZBPackage.m
+++ b/Zebra/Model/ZBPackage.m
@@ -500,9 +500,18 @@
     return [[ZBPackageManager sharedInstance] canReinstallPackage:self];
 }
 
+NSComparisonResult (^versionComparator)(NSString *, NSString *) = ^NSComparisonResult(NSString *version1, NSString *version2) {
+    int result = compare(version1.UTF8String, version2.UTF8String);
+    if (result > 0)
+        return NSOrderedAscending;
+    if (result < 0)
+        return NSOrderedDescending;
+    return NSOrderedSame;
+};
+
 - (NSArray <NSString *> *)allVersions {
     if (!_allVersions || _allVersions.count == 0) {
-        _allVersions = [[ZBPackageManager sharedInstance] allVersionsOfPackage:self];
+        _allVersions = [[[ZBPackageManager sharedInstance] allVersionsOfPackage:self] sortedArrayUsingComparator:versionComparator];
     }
     
     return _allVersions;
@@ -514,15 +523,6 @@
     
     return allVersions;
 }
-
-NSComparisonResult (^versionComparator)(NSString *, NSString *) = ^NSComparisonResult(NSString *version1, NSString *version2) {
-    int result = compare(version1.UTF8String, version2.UTF8String);
-    if (result > 0)
-        return NSOrderedAscending;
-    if (result < 0)
-        return NSOrderedDescending;
-    return NSOrderedSame;
-};
 
 - (NSArray <NSString *> *)lesserVersions {
     NSMutableArray *versions = self.otherVersions.mutableCopy;


### PR DESCRIPTION
There are lines in `ZBPackage.m` that look like this:
```
NSString *latestVersion = allVersions[0];
```

This assumption is wrong, unless you can guarantee that `-[ZBPackage allVersions]` returns a sorted array of packages by version - the latest version is the first.

Impact: When you browse to a package from Sources tab, you may not get the latest version of the package because of the wrong assumption in code mentioned above.