### PR TITLE
[Search] Prevent race condition in packages search

### DIFF
--- a/Zebra/UI/Search/ZBSearchViewController.m
+++ b/Zebra/UI/Search/ZBSearchViewController.m
@@ -138,24 +138,26 @@
     
     NSUInteger selectedIndex = searchController.searchBar.selectedScopeButtonIndex;
     if (searchResults.count == 0) [self showSpinner]; // Only show the spinner if this is the initial search
-    switch (selectedIndex) {
-        case 0: {
-            [packageManager searchForPackagesByName:strippedString completion:^(NSArray<ZBPackage *> * _Nonnull packages) {
-                updateTable(packages);
-            }];
-            break;
-        }
-        case 1: {
-            [packageManager searchForPackagesByDescription:strippedString completion:^(NSArray<ZBPackage *> * _Nonnull packages) {
-                updateTable(packages);
-            }];
-            break;
-        }
-        case 2: {
-            [packageManager searchForPackagesByAuthorWithName:strippedString email:nil completion:^(NSArray<ZBPackage *> * _Nonnull packages) {
-                updateTable(packages);
-            }];
-            break;
+    @synchronized (self) {
+        switch (selectedIndex) {
+            case 0: {
+                [packageManager searchForPackagesByName:strippedString completion:^(NSArray<ZBPackage *> * _Nonnull packages) {
+                    updateTable(packages);
+                }];
+                break;
+            }
+            case 1: {
+                [packageManager searchForPackagesByDescription:strippedString completion:^(NSArray<ZBPackage *> * _Nonnull packages) {
+                    updateTable(packages);
+                }];
+                break;
+            }
+            case 2: {
+                [packageManager searchForPackagesByAuthorWithName:strippedString email:nil completion:^(NSArray<ZBPackage *> * _Nonnull packages) {
+                    updateTable(packages);
+                }];
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
A crash may occur from continuously typing in a search input as reloading table action will be invoked multiple times.