### PR TITLE
[Sources] Remove lists folder on Clear Sources Cache

### DIFF
--- a/Zebra/Managers/ZBDatabaseManager.m
+++ b/Zebra/Managers/ZBDatabaseManager.m
@@ -215,6 +215,7 @@ typedef NS_ENUM(NSUInteger, ZBDatabaseStatementType) {
     
     ZBLog(@"[Zebra] Migrating database from version %d to %d", version, DATABASE_VERSION);
     
+    [[NSFileManager defaultManager] removeItemAtPath:[ZBAppDelegate listsLocation] error:NULL];
     [self performTransaction:^{
         switch (version + 1) {
             case 1: {


### PR DESCRIPTION
An observation yields that there are unused release and packages files (those that have their corresponding repository removed) lying around. This could create undefined behaviors.