### PR TITLE
[Actions] Use newer checkout action in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v2
       with:
         submodules: true
         token: ${{ secrets.GIT_TOKEN }}
@@ -19,7 +19,7 @@ jobs:
       run: brew install ldid fakeroot make
 
     - name: Install Theos
-      uses: actions/checkout@main
+      uses: actions/checkout@v2
       with:
         repository: theos/theos
         path: theos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,16 +10,16 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
       with:
-        submodules: recursive
+        submodules: true
         token: ${{ secrets.GIT_TOKEN }}
 
     - name: Install Theos Dependencies
       run: brew install ldid fakeroot make
 
     - name: Install Theos
-      uses: actions/checkout@master
+      uses: actions/checkout@main
       with:
         repository: theos/theos
         path: theos


### PR DESCRIPTION
This pull request updates the build workflow to use the latest version of the checkout action and changes the fetching of the submodules to `true` as we don't need the SDWebImage and LNPopupController submodules. It also fixes the commit used for the Plains submodule.