### PR TITLE
[Packages] Depiction scroll height bug fix (#1951)

### DIFF
--- a/Zebra/Tabs/Packages/Controllers/ZBPackageDepictionViewController.m
+++ b/Zebra/Tabs/Packages/Controllers/ZBPackageDepictionViewController.m
@@ -304,7 +304,7 @@ typedef NS_ENUM(NSUInteger, ZBPackageInfoOrder) {
             if (!error) {
                 if ([completed isEqualToString:@"complete"]) {
                     //body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight
-                    NSString *question = @"var body = document.body, html = document.documentElement; var height = Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight); height";
+                    NSString *question = @"var body = document.body, html = document.documentElement; var height = Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.offsetHeight); height";
                     [webView evaluateJavaScript:question completionHandler:^(id _Nullable height, NSError * _Nullable error) {
                         [self layoutDepictionWebView:webView height:[height floatValue]];
                     }];


### PR DESCRIPTION
Setting the depiction's scroll view height to `html.scrollHeight` while both html and body tag heights are set to 100% will create a loop, causing the scroll view's height to infinitely grow.

Fixes #1951