### PR TITLE
[theme] Toggle system appearance seamlessly

### DIFF
--- a/Zebra/Tabs/Home/Settings/Display/ZBDisplaySettingsTableViewController.m
+++ b/Zebra/Tabs/Home/Settings/Display/ZBDisplaySettingsTableViewController.m
@@ -78,7 +78,7 @@ typedef NS_ENUM(NSInteger, ZBSectionOrder) {
         case ZBSectionPureBlack:
             return 1;
         default:
-            return 0;
+            return 1;
     }
 }
 
@@ -260,6 +260,7 @@ typedef NS_ENUM(NSInteger, ZBSectionOrder) {
     pureBlackMode = setting;
     [ZBSettings setPureBlackMode:setting];
     [self updateInterfaceStyle];
+    [self configureTheme];
 }
 
 - (void)updateInterfaceStyle {
@@ -267,7 +268,9 @@ typedef NS_ENUM(NSInteger, ZBSectionOrder) {
     interfaceStyle = [ZBSettings interfaceStyle];
     
     [[ZBThemeManager sharedInstance] updateInterfaceStyle];
-    [self configureTheme];
+    if ([ZBThemeManager useCustomTheming]) {
+        [self configureTheme];
+    }
 }
 
 - (void)configureTheme {
@@ -280,7 +283,9 @@ typedef NS_ENUM(NSInteger, ZBSectionOrder) {
             cell.backgroundColor = [UIColor cellBackgroundColor];
         }
     }];
-    [self.tableView reloadData];
+    if ([ZBThemeManager useCustomTheming]) {
+        [self.tableView reloadData];
+    }
 }
 
 @end

--- a/Zebra/Tabs/Home/Settings/Display/ZBDisplaySettingsTableViewController.m
+++ b/Zebra/Tabs/Home/Settings/Display/ZBDisplaySettingsTableViewController.m
@@ -74,11 +74,11 @@ typedef NS_ENUM(NSInteger, ZBSectionOrder) {
             if (@available(iOS 13.0, *)) {
                 if (!usesSystemAppearance) return 2;
             }
-            else if (section == 1 && !usesSystemAppearance) return 2;
+            else if (section == ZBSectionSystemStyle && !usesSystemAppearance) return 2;
         case ZBSectionPureBlack:
             return 1;
         default:
-            return 1;
+            return 0;
     }
 }
 
@@ -167,6 +167,8 @@ typedef NS_ENUM(NSInteger, ZBSectionOrder) {
             }
         }
         case ZBSectionStyleChooser: {
+            // ZBSectionStyleChooser can only be the last section if system appearance is not natively supported - and this rather points pure black mode section
+            if (section == [tableView numberOfSections] - 1) break;
             if (!usesSystemAppearance) {
                 UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
                 UITableViewCell *otherCell;
@@ -265,10 +267,20 @@ typedef NS_ENUM(NSInteger, ZBSectionOrder) {
     interfaceStyle = [ZBSettings interfaceStyle];
     
     [[ZBThemeManager sharedInstance] updateInterfaceStyle];
-    
+    [self configureTheme];
+}
+
+- (void)configureTheme {
     [UIView animateWithDuration:0.5 animations:^{
         self.tableView.backgroundColor = [UIColor groupedTableViewBackgroundColor];
+        self.tableView.separatorColor = [UIColor cellSeparatorColor];
+        self.tableView.tableHeaderView.backgroundColor = [UIColor groupedTableViewBackgroundColor];
+        for (UITableViewCell *cell in [self.tableView visibleCells]) {
+            cell.textLabel.textColor = [UIColor primaryTextColor];
+            cell.backgroundColor = [UIColor cellBackgroundColor];
+        }
     }];
+    [self.tableView reloadData];
 }
 
 @end

--- a/Zebra/Tabs/Sources/Controllers/ZBSourceSectionsListTableViewController.m
+++ b/Zebra/Tabs/Sources/Controllers/ZBSourceSectionsListTableViewController.m
@@ -276,8 +276,6 @@
     numberFormatter.locale = [NSLocale currentLocale];
     numberFormatter.numberStyle = NSNumberFormatterDecimalStyle;
     numberFormatter.usesGroupingSeparator = YES;
-    cell.selectedBackgroundView = [[UIView alloc] initWithFrame:CGRectZero];
-    cell.selectedBackgroundView.backgroundColor = [UIColor cellSelectedBackgroundColor];
     
     if (indexPath.row == 0) {
         cell.textLabel.text = NSLocalizedString(@"All Packages", @"");

--- a/Zebra/Theme/ZBThemeManager.m
+++ b/Zebra/Theme/ZBThemeManager.m
@@ -194,9 +194,6 @@
     [[UITableView appearance] setBackgroundColor:[UIColor groupedTableViewBackgroundColor]];
     [[UITableViewCell appearance] setBackgroundColor:[UIColor cellBackgroundColor]];
     [[UITableViewCell appearance] setTintColor:[UIColor accentColor]];
-    UIView *selectedBackgroundView = [[UIView alloc] initWithFrame:CGRectZero];
-    selectedBackgroundView.backgroundColor = [UIColor cellSelectedBackgroundColor];
-    [[UITableViewCell appearance] setSelectedBackgroundView:selectedBackgroundView];
     if ([ZBThemeManager useCustomTheming]) {
         [[UITableView appearance] setSeparatorColor:[UIColor cellSeparatorColor]];
         [[UILabel appearanceWhenContainedInInstancesOfClasses:@[[UITableViewCell class], [UITableView class]]] setTextColor:[UIColor primaryTextColor]];

--- a/Zebra/Theme/ZBThemeManager.m
+++ b/Zebra/Theme/ZBThemeManager.m
@@ -194,6 +194,9 @@
     [[UITableView appearance] setBackgroundColor:[UIColor groupedTableViewBackgroundColor]];
     [[UITableViewCell appearance] setBackgroundColor:[UIColor cellBackgroundColor]];
     [[UITableViewCell appearance] setTintColor:[UIColor accentColor]];
+    UIView *selectedBackgroundView = [[UIView alloc] initWithFrame:CGRectZero];
+    selectedBackgroundView.backgroundColor = [UIColor cellSelectedBackgroundColor];
+    [[UITableViewCell appearance] setSelectedBackgroundView:selectedBackgroundView];
     if ([ZBThemeManager useCustomTheming]) {
         [[UITableView appearance] setSeparatorColor:[UIColor cellSeparatorColor]];
         [[UILabel appearanceWhenContainedInInstancesOfClasses:@[[UITableViewCell class], [UITableView class]]] setTextColor:[UIColor primaryTextColor]];


### PR DESCRIPTION
- (iOS 12-) Fixed certain elements not changing color when the theme has changed.
- Prevented triggering theme change when tapping on pure dark mode cell.