### PR TITLE
Bug Fixes & Updates (mainly for iOS 9-10)

### DIFF
--- a/Zebra/Downloads/ZBDownloadManager.m
+++ b/Zebra/Downloads/ZBDownloadManager.m
@@ -360,7 +360,7 @@
     switch ([ZBDevice jailbreak]) {
     case ZBJailbreakOdyssey:
         return ([host isEqualToString:@"apt.saurik.com"] || [host isEqualToString:@"electrarepo64.coolstar.org"] || [host isEqualToString:@"repo.chimera.sh"] || [host isEqualToString:@"apt.bingner.com"]);
-    case ZBJailbreakCheckrain:
+    case ZBJailbreakCheckra1n:
         return ([host isEqualToString:@"apt.saurik.com"] || [host isEqualToString:@"electrarepo64.coolstar.org"] || [host isEqualToString:@"repo.chimera.sh"]);
     case ZBJailbreakChimera:
         return ([host isEqualToString:@"checkra.in"] || [host isEqualToString:@"apt.bingner.com"] || [host isEqualToString:@"apt.saurik.com"] || [host isEqualToString:@"electrarepo64.coolstar.org"]);

--- a/Zebra/Tabs/Home/Community Sources/ZBCommunitySourcesTableViewController.m
+++ b/Zebra/Tabs/Home/Community Sources/ZBCommunitySourcesTableViewController.m
@@ -107,7 +107,7 @@
         NSDictionary *dict = @{@"type" : @"transfer",
                                 @"name" : @"Sileo",
                                 @"label": [NSString stringWithFormat:NSLocalizedString(@"Transfer sources from %@ to Zebra", @""), @"Sileo"],
-                                @"url"  : [ZBDevice jailbreak] == ZBJailbreakCheckrain ? @"file://" @INSTALL_PREFIX @"/etc/apt/sileo.list.d/" : @"file://" @INSTALL_PREFIX @"/etc/apt/sources.list.d/",
+                                @"url"  : [ZBDevice jailbreak] == ZBJailbreakCheckra1n ? @"file://" @INSTALL_PREFIX @"/etc/apt/sileo.list.d/" : @"file://" @INSTALL_PREFIX @"/etc/apt/sources.list.d/",
                                 @"ext"  : @"sources",
                                 @"icon" : @"file://" @INSTALL_PREFIX @"/Applications/Sileo.app/AppIcon60x60@2x.png"};
         [result addObject:dict];
@@ -117,7 +117,7 @@
 
 - (NSArray *)utilitySources {
     NSMutableArray *result = [NSMutableArray new];
-    if ([ZBDevice jailbreak] == ZBJailbreakCheckrain) {
+    if ([ZBDevice jailbreak] == ZBJailbreakCheckra1n) {
         if ([ZBDevice bootstrap] == ZBBootstrapProcursus) {
             NSDictionary *dict = @{@"type": @"utility",
                                    @"name": @"Procursus",

--- a/Zebra/Tabs/Home/Settings/Display/ZBDisplaySettingsTableViewController.m
+++ b/Zebra/Tabs/Home/Settings/Display/ZBDisplaySettingsTableViewController.m
@@ -262,21 +262,28 @@ typedef NS_ENUM(NSInteger, ZBSectionOrder) {
 }
 
 - (void)updateInterfaceStyle {
-
-    usesSystemAppearance = [ZBSettings usesSystemAppearance];
-    interfaceStyle = [ZBSettings interfaceStyle];
     
-    [UIView animateWithDuration:0.1 animations:^{
+    if (@available(iOS 13.0, *)) {
+        usesSystemAppearance = [ZBSettings usesSystemAppearance];
+        interfaceStyle = [ZBSettings interfaceStyle];
         [[ZBThemeManager sharedInstance] updateInterfaceStyle];
+    } else {
+        usesSystemAppearance = [ZBSettings usesSystemAppearance];
+        interfaceStyle = [ZBSettings interfaceStyle];
+        [[ZBThemeManager sharedInstance] updateInterfaceStyle];
+
         self.tableView.backgroundColor = [UIColor groupedTableViewBackgroundColor];
         self.tableView.separatorColor = [UIColor cellSeparatorColor];
         self.tableView.tableHeaderView.backgroundColor = [UIColor groupedTableViewBackgroundColor];
+        
         for (UITableViewCell *cell in [self.tableView visibleCells]) {
             cell.textLabel.textColor = [UIColor primaryTextColor];
             cell.backgroundColor = [UIColor cellBackgroundColor];
         }
+        
         [self.tableView reloadData];
-    }];
+    
+    }
     
 }
 

--- a/Zebra/Tabs/Home/Settings/Display/ZBDisplaySettingsTableViewController.m
+++ b/Zebra/Tabs/Home/Settings/Display/ZBDisplaySettingsTableViewController.m
@@ -262,28 +262,21 @@ typedef NS_ENUM(NSInteger, ZBSectionOrder) {
 }
 
 - (void)updateInterfaceStyle {
-    
-    if (@available(iOS 13.0, *)) {
-        usesSystemAppearance = [ZBSettings usesSystemAppearance];
-        interfaceStyle = [ZBSettings interfaceStyle];
-        [[ZBThemeManager sharedInstance] updateInterfaceStyle];
-    } else {
-        usesSystemAppearance = [ZBSettings usesSystemAppearance];
-        interfaceStyle = [ZBSettings interfaceStyle];
-        [[ZBThemeManager sharedInstance] updateInterfaceStyle];
 
+    usesSystemAppearance = [ZBSettings usesSystemAppearance];
+    interfaceStyle = [ZBSettings interfaceStyle];
+    
+    [UIView animateWithDuration:0.1 animations:^{
+        [[ZBThemeManager sharedInstance] updateInterfaceStyle];
         self.tableView.backgroundColor = [UIColor groupedTableViewBackgroundColor];
         self.tableView.separatorColor = [UIColor cellSeparatorColor];
         self.tableView.tableHeaderView.backgroundColor = [UIColor groupedTableViewBackgroundColor];
-        
         for (UITableViewCell *cell in [self.tableView visibleCells]) {
             cell.textLabel.textColor = [UIColor primaryTextColor];
             cell.backgroundColor = [UIColor cellBackgroundColor];
         }
-        
         [self.tableView reloadData];
-    
-    }
+    }];
     
 }
 

--- a/Zebra/Tabs/Home/Settings/Display/ZBDisplaySettingsTableViewController.m
+++ b/Zebra/Tabs/Home/Settings/Display/ZBDisplaySettingsTableViewController.m
@@ -74,7 +74,7 @@ typedef NS_ENUM(NSInteger, ZBSectionOrder) {
             if (@available(iOS 13.0, *)) {
                 if (!usesSystemAppearance) return 2;
             }
-            else if (section == 1 && !usesSystemAppearance) return 2;
+            else if (section == ZBSectionSystemStyle && !usesSystemAppearance) return 2;
         case ZBSectionPureBlack:
             return 1;
         default:
@@ -167,6 +167,7 @@ typedef NS_ENUM(NSInteger, ZBSectionOrder) {
             }
         }
         case ZBSectionStyleChooser: {
+            if (section == [tableView numberOfSections] - 1) break;
             if (!usesSystemAppearance) {
                 UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
                 UITableViewCell *otherCell;
@@ -261,14 +262,22 @@ typedef NS_ENUM(NSInteger, ZBSectionOrder) {
 }
 
 - (void)updateInterfaceStyle {
+
     usesSystemAppearance = [ZBSettings usesSystemAppearance];
     interfaceStyle = [ZBSettings interfaceStyle];
     
-    [[ZBThemeManager sharedInstance] updateInterfaceStyle];
-    
-    [UIView animateWithDuration:0.5 animations:^{
+    [UIView animateWithDuration:0.1 animations:^{
+        [[ZBThemeManager sharedInstance] updateInterfaceStyle];
         self.tableView.backgroundColor = [UIColor groupedTableViewBackgroundColor];
+        self.tableView.separatorColor = [UIColor cellSeparatorColor];
+        self.tableView.tableHeaderView.backgroundColor = [UIColor groupedTableViewBackgroundColor];
+        for (UITableViewCell *cell in [self.tableView visibleCells]) {
+            cell.textLabel.textColor = [UIColor primaryTextColor];
+            cell.backgroundColor = [UIColor cellBackgroundColor];
+        }
+        [self.tableView reloadData];
     }];
+    
 }
 
 @end

--- a/Zebra/Tabs/Home/Settings/Display/ZBDisplaySettingsTableViewController.m
+++ b/Zebra/Tabs/Home/Settings/Display/ZBDisplaySettingsTableViewController.m
@@ -262,22 +262,25 @@ typedef NS_ENUM(NSInteger, ZBSectionOrder) {
 }
 
 - (void)updateInterfaceStyle {
-
-    usesSystemAppearance = [ZBSettings usesSystemAppearance];
-    interfaceStyle = [ZBSettings interfaceStyle];
-    
-    [UIView animateWithDuration:0.1 animations:^{
+    if (@available(iOS 13.0, *)) {
+        usesSystemAppearance = [ZBSettings usesSystemAppearance];
+        interfaceStyle = [ZBSettings interfaceStyle];
+        [[ZBThemeManager sharedInstance] updateInterfaceStyle];
+    } else {
+        usesSystemAppearance = [ZBSettings usesSystemAppearance];
+        interfaceStyle = [ZBSettings interfaceStyle];
         [[ZBThemeManager sharedInstance] updateInterfaceStyle];
         self.tableView.backgroundColor = [UIColor groupedTableViewBackgroundColor];
         self.tableView.separatorColor = [UIColor cellSeparatorColor];
         self.tableView.tableHeaderView.backgroundColor = [UIColor groupedTableViewBackgroundColor];
+        
         for (UITableViewCell *cell in [self.tableView visibleCells]) {
             cell.textLabel.textColor = [UIColor primaryTextColor];
             cell.backgroundColor = [UIColor cellBackgroundColor];
         }
+        
         [self.tableView reloadData];
-    }];
-    
+    }
 }
 
 @end

--- a/Zebra/Tabs/Sources/Controllers/ZBSourceListTableViewController.m
+++ b/Zebra/Tabs/Sources/Controllers/ZBSourceListTableViewController.m
@@ -434,34 +434,38 @@
 }
 
 - (void)addSourceFromAlertController:(UIAlertController *)alertController {
+    
     NSString *urlString = [alertController.textFields[0].text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-    if ([urlString hasPrefix:@"http:"]) {
-        // Warn user for insecure source (has low self esteem)
-        UIAlertController *insecureSource = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"You are adding a repository that is not secure", @"") message:NSLocalizedString(@"Data downloaded from this repository might not be encrypted. Are you sure you want to add it?", @"") preferredStyle:UIAlertControllerStyleAlert];
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    if ([defaults boolForKey:@"HTTPAlert"]) {
+        if ([urlString hasPrefix:@"http:"]) {
+            // Warn user for insecure source (has low self esteem)
+            UIAlertController *insecureSource = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"You are adding a repository that is not secure", @"") message:NSLocalizedString(@"Data downloaded from this repository might not be encrypted. Are you sure you want to add it?", @"") preferredStyle:UIAlertControllerStyleAlert];
 
-        UIAlertAction *addInsecure = [UIAlertAction actionWithTitle:NSLocalizedString(@"Add", @"") style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-            NSString *repoString = [urlString copy];
-            if (![repoString hasSuffix:@"/"]) {
-                repoString = [repoString stringByAppendingString:@"/"];
-            }
+            UIAlertAction *addInsecure = [UIAlertAction actionWithTitle:NSLocalizedString(@"Add", @"") style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+                NSString *repoString = [urlString copy];
+                if (![repoString hasSuffix:@"/"]) {
+                    repoString = [repoString stringByAppendingString:@"/"];
+                }
 
-            NSURL *sourceURL = [NSURL URLWithString:repoString];
-            [self checkSourceURL:sourceURL];
-        }];
-        [insecureSource addAction:addInsecure];
+                NSURL *sourceURL = [NSURL URLWithString:repoString];
+                [self checkSourceURL:sourceURL];
+            }];
+            [insecureSource addAction:addInsecure];
 
-        UIAlertAction *edit = [UIAlertAction actionWithTitle:NSLocalizedString(@"Edit", @"") style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-            [self showAddSourceAlert:urlString];
-        }];
-        [insecureSource addAction:edit];
+            UIAlertAction *edit = [UIAlertAction actionWithTitle:NSLocalizedString(@"Edit", @"") style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+                [self showAddSourceAlert:urlString];
+            }];
+            [insecureSource addAction:edit];
 
-        UIAlertAction *cancel = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"") style:UIAlertActionStyleCancel handler:nil];
-        [insecureSource addAction:cancel];
+            UIAlertAction *cancel = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"") style:UIAlertActionStyleCancel handler:nil];
+            [insecureSource addAction:cancel];
 
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self presentViewController:insecureSource animated:YES completion:nil];
-        });
-        return;
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self presentViewController:insecureSource animated:YES completion:nil];
+            });
+            return;
+        }
     }
 
     if (![urlString hasSuffix:@"/"]) {

--- a/Zebra/ZBDevice.h
+++ b/Zebra/ZBDevice.h
@@ -15,7 +15,7 @@ typedef NS_ENUM(NSUInteger, ZBJailbreak) {
     ZBJailbreakUnknown,
     ZBJailbreakSimulated,
     ZBJailbreakLegacy,
-    ZBJailbreakCheckrain,
+    ZBJailbreakCheckra1n,
     ZBJailbreakUncover,
     ZBJailbreakElectra,
     ZBJailbreakChimera,
@@ -23,7 +23,23 @@ typedef NS_ENUM(NSUInteger, ZBJailbreak) {
     ZBJailbreakTaurine,
     ZBJailbreakCheyote,
     ZBJailbreakXinaA15,
-    ZBJailbreakPalerain
+    ZBJailbreakPalera1n,
+    ZBJailbreakSocket,
+    ZBJailbreakH3lix,
+    ZBJailbreakBlizzard9,
+    ZBJailbreakOpenpwnage,
+    ZBJailbreakHomeDepot,
+    ZBJailbreakKok3shi,
+    ZBJailbreakP0laris,
+    ZBJailbreakDoubleH3lix,
+    ZBJailbreakMeridian,
+    ZBJailbreakYalu,
+    ZBJailbreakSaigon,
+    ZBJailbreakG0blin,
+    ZBJailbreakKok3shiX,
+    ZBJailbreakMineekJB32,
+    ZBJailbreakMineekJB64,
+    ZBJailbreakMineekJB
 };
 
 typedef NS_ENUM(NSUInteger, ZBBootstrap) {

--- a/Zebra/ZBDevice.h
+++ b/Zebra/ZBDevice.h
@@ -24,6 +24,7 @@ typedef NS_ENUM(NSUInteger, ZBJailbreak) {
     ZBJailbreakCheyote,
     ZBJailbreakXinaA15,
     ZBJailbreakPalera1n,
+    ZBJailbreakFugu15,
     ZBJailbreakSocket,
     ZBJailbreakH3lix,
     ZBJailbreakBlizzard9,

--- a/Zebra/ZBDevice.m
+++ b/Zebra/ZBDevice.m
@@ -374,11 +374,17 @@ static ZBBootstrap bootstrap = ZBBootstrapUnknown;
     } else if ([self _isRegularDirectory:@"/var/Liy/xina"]) {
         jailbreak = ZBJailbreakXinaA15;
     } else if (@available(iOS 16, *)) {
-        // TODO: TEMPORARY until palerain 1.4 has been out long enough
+#if __arm64e__
         jailbreak = ZBJailbreakUnknown;
-    } else if (@available(iOS 15, *)) {
-        // TODO: TEMPORARY until palerain 1.4 has been out long enough
+#else
         jailbreak = ZBJailbreakPalera1n;
+#endif
+    } else if (@available(iOS 15, *)) {
+#if __arm64e__
+        jailbreak = ZBJailbreakFugu15;
+#else
+        jailbreak = ZBJailbreakPalera1n;
+#endif
     } else if (@available(iOS 11, *)) {
         jailbreak = ZBJailbreakUnknown;
     } else {
@@ -427,9 +433,9 @@ static ZBBootstrap bootstrap = ZBBootstrapUnknown;
 
 + (NSString *)jailbreakName {
     switch (jailbreak) {
-    case ZBJailbreakUnknown:   return NSLocalizedString(@"Unknown Jailbreak", @"");
-    case ZBJailbreakSimulated: return NSLocalizedString(@"Demo Mode", @"");
-    case ZBJailbreakLegacy:    return NSLocalizedString(@"Legacy Jailbreak", @"");
+    case ZBJailbreakUnknown:      return NSLocalizedString(@"Unknown Jailbreak", @"");
+    case ZBJailbreakSimulated:    return NSLocalizedString(@"Demo Mode", @"");
+    case ZBJailbreakLegacy:       return NSLocalizedString(@"Legacy Jailbreak", @"");
     case ZBJailbreakCheckra1n:    return @"checkra1n";
     case ZBJailbreakUncover:      return @"unc0ver";
     case ZBJailbreakElectra:      return @"Electra";
@@ -439,6 +445,7 @@ static ZBBootstrap bootstrap = ZBBootstrapUnknown;
     case ZBJailbreakCheyote:      return @"Cheyote";
     case ZBJailbreakXinaA15:      return @"XinaA15";
     case ZBJailbreakPalera1n:     return @"palera1n";
+    case ZBJailbreakFugu15:       return @"Fugu15";
     case ZBJailbreakSocket:       return @"socket";
     case ZBJailbreakH3lix:        return @"h3lix";
     case ZBJailbreakBlizzard9:    return @"Blizzard";

--- a/Zebra/ZBDevice.m
+++ b/Zebra/ZBDevice.m
@@ -285,12 +285,14 @@ static ZBBootstrap bootstrap = ZBBootstrapUnknown;
 + (void)load {
     [super load];
 
+    struct utsname name;
+    uname(&name);
     isPrefixed = ![@INSTALL_PREFIX isEqualToString:@""];
 
     if (self.needsSimulation) {
         jailbreak = ZBJailbreakSimulated;
     } else if ([self _isRegularFile:@"/var/checkra1n.dmg"] || [self _isRegularDirectory:@"/binpack"]) {
-        jailbreak = ZBJailbreakCheckrain;
+        jailbreak = ZBJailbreakCheckra1n;
     } else if ([self _isRegularFile:@"/.installed_unc0ver"]) {
         jailbreak = ZBJailbreakUncover;
     } else if ([self _isRegularDirectory:@"/electra"]) {
@@ -304,7 +306,41 @@ static ZBBootstrap bootstrap = ZBBootstrapUnknown;
     } else if ([self _isRegularFile:@INSTALL_PREFIX @"/.installed_cheyote"]) {
         jailbreak = ZBJailbreakCheyote;
     } else if ([self _isRegularFile:@INSTALL_PREFIX @"/.installed_palera1n"]) {
-        jailbreak = ZBJailbreakPalerain;
+        jailbreak = ZBJailbreakPalera1n;
+    } else if ([self _isRegularFile:@"/.installed_socket"]) {
+        jailbreak = ZBJailbreakSocket;
+    } else if ([self _isRegularFile:@"/.p0laris"]) {
+        jailbreak = ZBJailbreakP0laris;
+    } else if ([self _isRegularFile:@"/.installed-openpwnage"]) {
+        jailbreak = ZBJailbreakOpenpwnage;
+    } else if ([self _isRegularFile:@"/.installed_home_depot"]) {
+        jailbreak = ZBJailbreakHomeDepot;
+    } else if ([self _isRegularFile:@"/.installed_mineekJB"]) {
+        jailbreak = ZBJailbreakMineekJB;
+    } else if ([self _isRegularFile:@"/.installed_mineekJB32"]) {
+        jailbreak = ZBJailbreakMineekJB32;
+    } else if ([self _isRegularFile:@"/.installed_mineekJB64"]) {
+        jailbreak = ZBJailbreakMineekJB64;
+    } else if ([self _isRegularFile:@"/.blizzardJB"]) {
+        jailbreak = ZBJailbreakBlizzard9;
+    } else if ([self _isRegularFile:@"/.installed_kok3shi"]) {
+        jailbreak = ZBJailbreakKok3shi;
+    } else if ([self _isRegularFile:@"/.installed_kok3shiX"]) {
+        jailbreak = ZBJailbreakKok3shiX;
+    } else if ([self _isRegularFile:@"/.meridian_installed"]) {
+        jailbreak = ZBJailbreakMeridian;
+    } else if ([self _isRegularFile:@"/.installed_yaluX"]) {
+        jailbreak = ZBJailbreakYalu;
+    } else if ([self _isRegularFile:@"/.installed_g0blin"]) {
+        jailbreak = ZBJailbreakG0blin;
+    } else if (strstr(name.version, "SaigonARM")) {
+        jailbreak = ZBJailbreakSaigon;
+    } else if (strstr(name.version, "MarijuanARM")) {
+#if __arm64__
+        jailbreak = ZBJailbreakDoubleH3lix;
+#else
+        jailbreak = ZBJailbreakH3lix;
+#endif
     } else if ([self _isRegularDirectory:@"/var/Liy/xina"]) {
         jailbreak = ZBJailbreakXinaA15;
     } else if (@available(iOS 16, *)) {
@@ -312,7 +348,7 @@ static ZBBootstrap bootstrap = ZBBootstrapUnknown;
         jailbreak = ZBJailbreakUnknown;
     } else if (@available(iOS 15, *)) {
         // TODO: TEMPORARY until palerain 1.4 has been out long enough
-        jailbreak = ZBJailbreakPalerain;
+        jailbreak = ZBJailbreakPalera1n;
     } else if (@available(iOS 11, *)) {
         jailbreak = ZBJailbreakUnknown;
     } else {
@@ -364,15 +400,31 @@ static ZBBootstrap bootstrap = ZBBootstrapUnknown;
     case ZBJailbreakUnknown:   return NSLocalizedString(@"Unknown Jailbreak", @"");
     case ZBJailbreakSimulated: return NSLocalizedString(@"Demo Mode", @"");
     case ZBJailbreakLegacy:    return NSLocalizedString(@"Legacy Jailbreak", @"");
-    case ZBJailbreakCheckrain: return @"checkra1n";
-    case ZBJailbreakUncover:   return @"unc0ver";
-    case ZBJailbreakElectra:   return @"Electra";
-    case ZBJailbreakChimera:   return @"Chimera";
-    case ZBJailbreakOdyssey:   return @"Odyssey";
-    case ZBJailbreakTaurine:   return @"Taurine";
-    case ZBJailbreakCheyote:   return @"Cheyote";
-    case ZBJailbreakXinaA15:   return @"XinaA15";
-    case ZBJailbreakPalerain:  return @"palera1n";
+    case ZBJailbreakCheckra1n:    return @"checkra1n";
+    case ZBJailbreakUncover:      return @"unc0ver";
+    case ZBJailbreakElectra:      return @"Electra";
+    case ZBJailbreakChimera:      return @"Chimera";
+    case ZBJailbreakOdyssey:      return @"Odyssey";
+    case ZBJailbreakTaurine:      return @"Taurine";
+    case ZBJailbreakCheyote:      return @"Cheyote";
+    case ZBJailbreakXinaA15:      return @"XinaA15";
+    case ZBJailbreakPalera1n:     return @"palera1n";
+    case ZBJailbreakSocket:       return @"socket";
+    case ZBJailbreakH3lix:        return @"h3lix";
+    case ZBJailbreakBlizzard9:    return @"Blizzard";
+    case ZBJailbreakOpenpwnage:   return @"Openpwnage";
+    case ZBJailbreakHomeDepot:    return @"Home Depot";
+    case ZBJailbreakKok3shi:      return @"kok3shi";
+    case ZBJailbreakP0laris:      return @"p0laris";
+    case ZBJailbreakDoubleH3lix:  return @"DoubleH3lix";
+    case ZBJailbreakMeridian:     return @"Meridian";
+    case ZBJailbreakYalu:         return @"Yalu";
+    case ZBJailbreakSaigon:       return @"palera1n";
+    case ZBJailbreakG0blin:       return @"g0blin";
+    case ZBJailbreakKok3shiX:     return @"kok3shiX";
+    case ZBJailbreakMineekJB32:   return @"MineekJB (32bit)";
+    case ZBJailbreakMineekJB64:   return @"MineekJB (64bit)";
+    case ZBJailbreakMineekJB:     return @"MineekJB";
     }
 }
 

--- a/Zebra/ZBSettings.h
+++ b/Zebra/ZBSettings.h
@@ -148,6 +148,9 @@ extern NSString *const SendErrorReportsKey;
 + (BOOL)wantsAutoRefresh;
 + (void)setWantsAutoRefresh:(BOOL)autoRefresh;
 
++ (BOOL)wantsHTTPAlert;
++ (void)setWantsHTTPAlert:(BOOL)httpAlert;
+
 + (NSInteger)sourceRefreshTimeoutIndex;
 + (NSTimeInterval)sourceRefreshTimeout;
 + (void)setSourceRefreshTimeout:(NSNumber *)time;

--- a/Zebra/ZBSettings.m
+++ b/Zebra/ZBSettings.m
@@ -34,6 +34,7 @@ NSString *const FeaturedPackagesTypeKey = @"FeaturedPackagesType";
 NSString *const FeaturedSourceBlacklistKey = @"FeaturedSourceBlacklist";
 
 NSString *const WantsAutoRefreshKey = @"AutoRefresh";
+NSString *const WantsHTTPAlertKey = @"HTTPAlert";
 NSString *const SourceTimeoutKey = @"SourceTimeout";
 
 NSString *const WantsCommunityNewsKey = @"CommunityNews";
@@ -443,6 +444,25 @@ NSString *const SendErrorReportsKey = @"SendErrorReports";
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     
     [defaults setBool:autoRefresh forKey:WantsAutoRefreshKey];
+}
+
++ (BOOL)wantsHTTPAlert {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    
+    if (![defaults objectForKey:WantsHTTPAlertKey]) {
+        [self setWantsHTTPAlert:YES];
+        NSLog(@"%@", [defaults objectForKey:WantsHTTPAlertKey]);
+        return YES;
+    }
+    NSLog(@"%@", [defaults objectForKey:WantsHTTPAlertKey]);
+    return [defaults boolForKey:WantsHTTPAlertKey];
+}
+
++ (void)setWantsHTTPAlert:(BOOL)httpAlert {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSLog(@"%@", [defaults objectForKey:WantsHTTPAlertKey]);
+
+    [defaults setBool:httpAlert forKey:WantsHTTPAlertKey];
 }
 
 + (NSInteger)sourceRefreshTimeoutIndex {


### PR DESCRIPTION
## Updates:
- Added more jailbreak Zebra can detect (mainly iOS 9-10 ones)
   - Can close https://github.com/zbrateam/Zebra/issues/2019 
- Added toggle for showing HTTP warning, which is useful on legacy devices

## Fixes:
- Improved Dark Mode switching on iOS 9-12 (thanks [PoomSmart!](https://github.com/PoomSmart))
   - Used some code from: https://github.com/zbrateam/Zebra/pull/1988
- Fixed an issue with "Zebra doesn’t have permission to install packages..." on iOS 9-10
   - It seems the supersling permissions checks from v1.1.29/1.1.30 may cause issues for some, returning a false positive during the uid check. So I added a check to use the supersling permissions check from v1.1.28 if on iOS 9-10, otherwise it uses the current one.
 - Armv7 support is fully working (again), just need to use Xcode 13 or older when building

## Other:
- Changed checkrain to checkra1n because I'm picky 
- Changed palerain to palera1n because I'm picky 
- Removed temp detection for palera1n with permanent one
   - Checks if arm64 & iOS 15/16
   - No longer might say "Unknown" on iOS 16
- Added Fugu15 detection for future proofing
   - Checks for arm64e & iOS 15 (after Xina checks)



