### PR TITLE
Collection of small bug fixes

### DIFF
--- a/Zebra/Tabs/Home/Community Sources/ZBCommunitySourcesTableViewController.m
+++ b/Zebra/Tabs/Home/Community Sources/ZBCommunitySourcesTableViewController.m
@@ -165,18 +165,25 @@
         break;
 
     case ZBJailbreakPalera1n:
-        [result addObject:@{@"type": @"utility",
-                            @"name": @"Procursus",
-                            @"url" : @"https://apt.procurs.us/",
-                            @"icon": @"https://apt.procurs.us/CydiaIcon.png"}];
+        if ([ZBDevice isPrefixed]) {
+            [result addObject:@{@"type": @"utility",
+                                @"name": @"Procursus",
+                                @"url" : @"https://apt.procurs.us/",
+                                @"icon": @"https://apt.procurs.us/CydiaIcon.png"}];
+            [result addObject:@{@"type": @"utility",
+                                @"name": @"ElleKit",
+                                @"url" : @"https://ellekit.space/",
+                                @"icon": @"https://ellekit.space/CydiaIcon.png"}];
+        } else {
+            [result addObject:@{@"type": @"utility",
+                                @"name": @"palera1n strap",
+                                @"url" : @"https://strap.palera.in/",
+                                @"icon": @"https://strap.palera.in/CydiaIcon.png"}];
+        }
         [result addObject:@{@"type": @"utility",
                             @"name": @"palera1n",
                             @"url" : @"https://repo.palera.in/",
                             @"icon": @"https://repo.palera.in/CydiaIcon.png"}];
-        [result addObject:@{@"type": @"utility",
-                            @"name": @"ElleKit",
-                            @"url" : @"https://ellekit.space/",
-                            @"icon": @"https://ellekit.space/CydiaIcon.png"}];
         break;
 
     case ZBJailbreakDopamine:

--- a/Zebra/Tabs/Home/Settings/Filters/ZBFilterSettingsTableViewController.m
+++ b/Zebra/Tabs/Home/Settings/Filters/ZBFilterSettingsTableViewController.m
@@ -344,7 +344,7 @@
         case 3: {
             UITableViewRowAction *deleteFilterAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleDestructive title:NSLocalizedString(@"Delete", @"") handler:^(UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath) {
                 switch (indexPath.section) {
-                    case 0: {
+                    case 1: {
                         NSString *section = self->filteredSections[indexPath.row];
                         [self->filteredSections removeObject:section];
                         
@@ -352,7 +352,7 @@
                         [tableView reloadSections:[NSIndexSet indexSetWithIndex:indexPath.section] withRowAnimation:UITableViewRowAnimationAutomatic];
                         break;
                     }
-                    case 1: {
+                    case 2: {
                         ZBSource *source = self->sources[indexPath.row];
                         [self->filteredSources removeObjectForKey:[source baseFilename]];
                         [self->sources removeObjectAtIndex:indexPath.row];
@@ -361,7 +361,7 @@
                         [tableView reloadSections:[NSIndexSet indexSetWithIndex:indexPath.section] withRowAnimation:UITableViewRowAnimationAutomatic];
                         break;
                     }
-                    case 2: {
+                    case 3: {
                         NSString *author = [self->blockedAuthors allKeys][indexPath.row];
                         [self->blockedAuthors removeObjectForKey:author];
 

--- a/Zebra/Tabs/Sources/Helpers/ZBBaseSource.m
+++ b/Zebra/Tabs/Sources/Helpers/ZBBaseSource.m
@@ -178,6 +178,11 @@
                     NSString *kind = [ZBDevice isPrefixed] ? @"iphoneos-arm64-rootless" : @"iphoneos-arm64";
                     distribution = [NSString stringWithFormat:@"%@/%d", kind, roundedCF];
                 }
+                else if ([repositoryURI containsString:@"strap.palera.in"]) {
+                    int roundedCF = 100.0 * floor((kCFCoreFoundationVersionNumber/100.0)+0.5);
+                    if (roundedCF > kCFCoreFoundationVersionNumber) roundedCF -= 100.0;
+                    distribution = [NSString stringWithFormat:@"%@/%d", @"iphoneos-arm64", roundedCF];
+                }
                 else {
                     distribution = [NSString stringWithFormat:@"ios/%.2f", kCFCoreFoundationVersionNumber];
                 }
@@ -186,7 +191,7 @@
             else if (count > 2) {
                 distribution = lineComponents[2];
                 
-                //Group all of the components into the components array
+                // Group all of the components into the components array
                 for (int i = 3; i < count; i++) {
                     NSString *component = lineComponents[i];
                     if (component)  {
@@ -243,7 +248,7 @@
 
 - (BOOL)hasCFVersionComponent:(NSString * _Nullable)repositoryURI_ {
     NSString *repositoryURI = repositoryURI_ ?: self.repositoryURI;
-    return [repositoryURI containsString:@"apt.procurs.us"] || [repositoryURI containsString:@"apt.bingner.com"] || [repositoryURI containsString:@"apt.saurik.com"];
+    return [repositoryURI containsString:@"apt.procurs.us"] || [repositoryURI containsString:@"apt.bingner.com"] || [repositoryURI containsString:@"apt.saurik.com"] || [repositoryURI containsString:@"strap.palera.in"];
 }
 
 - (void)verify:(nullable void (^)(ZBSourceVerificationStatus status))completion {

--- a/Zebra/Tabs/Sources/Helpers/ZBBaseSource.m
+++ b/Zebra/Tabs/Sources/Helpers/ZBBaseSource.m
@@ -176,7 +176,8 @@
                 if (roundedCF > kCFCoreFoundationVersionNumber) roundedCF -= 100.0;
                 
                 if ([repositoryURI containsString:@"apt.procurs.us"]) { // Have to treat this differently because its special
-                    NSString *kind = [ZBDevice isPrefixed] ? @"iphoneos-arm64-rootless" : @"iphoneos-arm64";
+                    NSString *dist = roundedCF >= 1900 ? @"" : @"iphoneos-arm64-rootless";
+                    NSString *kind = [ZBDevice isPrefixed] ? dist : @"iphoneos-arm64";
                     distribution = [NSString stringWithFormat:@"%@/%d", kind, roundedCF];
                 }
                 else if ([repositoryURI containsString:@"strap.palera.in"]) {

--- a/Zebra/Tabs/Sources/Helpers/ZBBaseSource.m
+++ b/Zebra/Tabs/Sources/Helpers/ZBBaseSource.m
@@ -158,7 +158,7 @@
     debLine = [debLine stringByTrimmingCharactersInSet:[NSCharacterSet newlineCharacterSet]];
     
     NSMutableArray *lineComponents = [[debLine componentsSeparatedByString:@" "] mutableCopy];
-    [lineComponents removeObject:@""]; //Remove empty strings from the line which exist for some reason
+    [lineComponents removeObject:@""]; // Remove empty strings from the line which exist for some reason
     
     NSUInteger count = [lineComponents count];
     NSString *archiveType = NULL;
@@ -172,15 +172,14 @@
             repositoryURI = lineComponents[1];
             
             if (([self hasCFVersionComponent:repositoryURI]) && count == 3) { // Sources that are known to use CF number in URL but for some reason aren't written in the sources.list properly
+                int roundedCF = 100.0 * floor((kCFCoreFoundationVersionNumber/100.0) + 0.5);
+                if (roundedCF > kCFCoreFoundationVersionNumber) roundedCF -= 100.0;
+                
                 if ([repositoryURI containsString:@"apt.procurs.us"]) { // Have to treat this differently because its special
-                    int roundedCF = 100.0 * floor((kCFCoreFoundationVersionNumber/100.0)+0.5);
-                    if (roundedCF > kCFCoreFoundationVersionNumber) roundedCF -= 100.0;
                     NSString *kind = [ZBDevice isPrefixed] ? @"iphoneos-arm64-rootless" : @"iphoneos-arm64";
                     distribution = [NSString stringWithFormat:@"%@/%d", kind, roundedCF];
                 }
                 else if ([repositoryURI containsString:@"strap.palera.in"]) {
-                    int roundedCF = 100.0 * floor((kCFCoreFoundationVersionNumber/100.0)+0.5);
-                    if (roundedCF > kCFCoreFoundationVersionNumber) roundedCF -= 100.0;
                     distribution = [NSString stringWithFormat:@"%@/%d", @"iphoneos-arm64", roundedCF];
                 }
                 else {

--- a/Zebra/ZBDevice.h
+++ b/Zebra/ZBDevice.h
@@ -40,7 +40,8 @@ typedef NS_ENUM(NSUInteger, ZBJailbreak) {
     ZBJailbreakMineekJB32,
     ZBJailbreakMineekJB64,
     ZBJailbreakMineekJB,
-    ZBJailbreakBakera1n
+    ZBJailbreakBakera1n,
+    ZBJailbreakP0insettia
 };
 
 typedef NS_ENUM(NSUInteger, ZBBootstrap) {

--- a/Zebra/ZBDevice.m
+++ b/Zebra/ZBDevice.m
@@ -343,7 +343,8 @@ static ZBBootstrap bootstrap = ZBBootstrapUnknown;
         @"/.meridian_installed":   @(ZBJailbreakMeridian),
         @"/.installed_yaluX":      @(ZBJailbreakYalu),
         @"/.installed_g0blin":     @(ZBJailbreakG0blin),
-        @"/cores/binpack/.installed_overlay": @(ZBJailbreakBakera1n)
+        @"/.installed_p0insettia": @(ZBJailbreakP0insettia),
+        @"/cores/binpack/.installed_overlay": @(ZBJailbreakBakera1n),
     };
     NSDictionary <NSString *, NSNumber *> *jailbreakInstalledDirs = @{
         @"/binpack":      @(ZBJailbreakCheckra1n),
@@ -430,13 +431,14 @@ static ZBBootstrap bootstrap = ZBBootstrapUnknown;
     case ZBJailbreakDoubleH3lix: return @"doubleH3lix";
     case ZBJailbreakMeridian:    return @"Meridian";
     case ZBJailbreakYalu:        return @"yalu";
-    case ZBJailbreakSaigon:      return @"palera1n";
+    case ZBJailbreakSaigon:      return @"Saïgon";
     case ZBJailbreakG0blin:      return @"g0blin";
     case ZBJailbreakKok3shiX:    return @"kok3shiX";
     case ZBJailbreakMineekJB32:  return @"mineekJB (32-bit)";
     case ZBJailbreakMineekJB64:  return @"mineekJB (64-bit)";
     case ZBJailbreakMineekJB:    return @"mineekJB";
     case ZBJailbreakBakera1n:    return @"bakera1n";
+    case ZBJailbreakP0insettia:  return @"p0insettia";
     }
 }
 

--- a/Zebra/ZBDevice.m
+++ b/Zebra/ZBDevice.m
@@ -250,7 +250,7 @@ static ZBBootstrap bootstrap = ZBBootstrapUnknown;
         if (@available(iOS 15, *)) {
             // Try userspace reboot
             NSLog(@"[Zebra] Trying userspace reboot");
-            if ([ZBCommand execute:@"launchctl" withArguments:@[@"userspace", @"reboot"] asRoot:YES]) {
+            if ([ZBCommand execute:@"launchctl" withArguments:@[@"reboot", @"userspace"] asRoot:YES]) {
                 return;
             }
         } else if (@available(iOS 11, *)) {
@@ -423,7 +423,7 @@ static ZBBootstrap bootstrap = ZBBootstrapUnknown;
     case ZBJailbreakDopamine:    return @"Dopamine";
     case ZBJailbreakSocket:      return @"socket";
     case ZBJailbreakH3lix:       return @"h3lix";
-    case ZBJailbreakBlizzard9:   return @"Blizzard";
+    case ZBJailbreakBlizzard9:   return @"Blizzard9";
     case ZBJailbreakOpenpwnage:  return @"Openpwnage";
     case ZBJailbreakHomeDepot:   return @"Home Depot";
     case ZBJailbreakKok3shi:     return @"kok3shi";


### PR DESCRIPTION
Changes in this pull request:

### Fixes crashing when removing a filter:
- **Where:** ZBFilterSettingsTableViewController.m:346
- **Cause:** indexPath.section off by 1 due to adding the 'Show Incompatible Packages' option
- **Fix:** Change section numbers in the switch case

### Fixes userspace reboot arguments:
- **Where:** ZBDevice.m:253
- **Cause:** Was set as `[@"userspace", @"reboot"]`
- **Fix:** Change arguments to `[@"reboot", @"userspace"]`

### Fixes Procursus dist url on iOS 16:
- **Where:** ZBBaseSource.m:178
- **Cause:** `iphoneos-arm64-rootless` does not exist for CF 1900
- **Fix:** Use `dist/CFVER` for iOS 16 and above

### Show correct community sources for palera1n (rootful):
On rootful, palera1n uses strap.palera.in as it's dist repo, so it will show that instead of Procursus

Also have fixed/added a few items in jailbreak detection